### PR TITLE
fix: reset toggle on reload

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -224,6 +224,11 @@ Learn more about {term}`Tailor`, {term}`Tuner` and {term}`Labeler`.
 </div>
 
 <script>
+    function init() {
+        document.getElementById('embed_model_yes').click();
+        document.getElementById('labeled_yes').click()
+    }
+    window.onload = init;
     function myfunction(event) {
         const answer = document.querySelector('input[name="embed_model"]:checked').value +document.querySelector('input[name="labeled"]:checked').value;
          document.querySelectorAll(".usage-card").forEach((input) => {


### PR DESCRIPTION
Added a function inside the script tag which is invoked on reload of the page(`window.onload`) and it sets the `yes` labelled toggle to `active`