### PR TITLE
feat: do not send embedding model but definition + checkpoint

### DIFF
--- a/finetuner/tuner/keras/__init__.py
+++ b/finetuner/tuner/keras/__init__.py
@@ -1,6 +1,5 @@
 from typing import Optional
 
-import numpy as np
 import tensorflow as tf
 from jina.helper import cached_property
 from jina.logging.profile import ProgressBar

--- a/tests/integration/labeler/test_tune_lstm.py
+++ b/tests/integration/labeler/test_tune_lstm.py
@@ -13,14 +13,27 @@ import torch
 
 from finetuner.toydata import generate_qa_match
 
+cur_dir = os.path.dirname(os.path.abspath(__file__))
+
 
 class LastCellPT(torch.nn.Module):
+
+    def __init__(self, extra_param, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._extra_param = extra_param
+        assert self._extra_param == 1
+
     def forward(self, x):
         out, _ = x
         return out[:, -1, :]
 
 
 class LastCellPD(paddle.nn.Layer):
+    def __init__(self, extra_param, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._extra_param = extra_param
+        assert self._extra_param == 1
+
     def forward(self, x):
         out, _ = x
         return out[:, -1, :]
@@ -61,6 +74,8 @@ def _run(framework_name, head_layer, port_expose):
         head_layer=head_layer,
         interactive=True,
         port_expose=port_expose,
+        model_definition_file_path=__file__,
+        extra_kwargs_model_init={'extra_param': 1},
     )
 
 


### PR DESCRIPTION
** This is a proposal and is in progress**

I am trying to get working around the finetuner, and one thing I would like to see is to remove this dependency of sharing the executor in a different thread.

I think that with this approach we can bypass this information. I am sure `paddle` has the same interfaces but I did not find. I will see if I take time to dig deeper.

Otherwise this is more of an inspiration work