### PR TITLE
feat(tuner): add miner for session dataset

### DIFF
--- a/.github/requirements-cicd-gpu.txt
+++ b/.github/requirements-cicd-gpu.txt
@@ -1,5 +1,5 @@
 https://github.com/jina-ai/jina/archive/refs/heads/master.zip
-tensorflow
+tensorflow==2.5.0
 paddlepaddle-gpu
 torch
 torchvision

--- a/.github/requirements-cicd-gpu.txt
+++ b/.github/requirements-cicd-gpu.txt
@@ -1,5 +1,5 @@
 https://github.com/jina-ai/jina/archive/refs/heads/master.zip
-tensorflow
+tensorflow==2.6.0
 paddlepaddle-gpu
 torch
 torchvision

--- a/.github/requirements-cicd-gpu.txt
+++ b/.github/requirements-cicd-gpu.txt
@@ -1,5 +1,5 @@
 https://github.com/jina-ai/jina/archive/refs/heads/master.zip
-tensorflow==2.6.0
+tensorflow
 paddlepaddle-gpu
 torch
 torchvision

--- a/.github/requirements-cicd.txt
+++ b/.github/requirements-cicd.txt
@@ -1,5 +1,5 @@
 https://github.com/jina-ai/jina/archive/refs/heads/master.zip
-tensorflow
+tensorflow==2.6.0
 paddlepaddle
 torch
 torchvision

--- a/.github/requirements-cicd.txt
+++ b/.github/requirements-cicd.txt
@@ -1,5 +1,5 @@
 https://github.com/jina-ai/jina/archive/refs/heads/master.zip
-tensorflow==2.6.0
+tensorflow
 paddlepaddle
 torch
 torchvision

--- a/.github/requirements-cicd.txt
+++ b/.github/requirements-cicd.txt
@@ -1,5 +1,5 @@
 https://github.com/jina-ai/jina/archive/refs/heads/master.zip
-tensorflow
+tensorflow==2.5.0
 paddlepaddle
 torch
 torchvision

--- a/finetuner/tuner/pytorch/miner.py
+++ b/finetuner/tuner/pytorch/miner.py
@@ -94,14 +94,12 @@ class TripletSessionMiner(BaseMiner):
         for session, group in groupby(sorted_labels_with_index, lambda x: x[0]):
             anchor_pos_session_labels = []
             anchor_pos_session_indices = []
-            neg_session_labels = []
             neg_session_indices = []
             for _, session_label, session_index in group:
                 if session_label >= 0:
                     anchor_pos_session_labels.append(session_label)
                     anchor_pos_session_indices.append(session_index)
                 else:
-                    neg_session_labels.append(session_label)
                     neg_session_indices.append(session_index)
             for anchor, pos in permutations(enumerate(anchor_pos_session_labels), 2):
                 for neg_idx in neg_session_indices:

--- a/finetuner/tuner/pytorch/miner.py
+++ b/finetuner/tuner/pytorch/miner.py
@@ -1,9 +1,27 @@
 import numpy as np
 from typing import List, Tuple
-from itertools import combinations
+from itertools import combinations, groupby
 
 from ..base import BaseMiner
 from ...helper import AnyTensor
+
+
+def _generate_all_possible_pairs(labels: List[int]):
+    return [
+        (left[0], right[0], 1) if left[1] == right[1] else (left[0], right[0], -1)
+        for left, right in combinations(enumerate(labels), 2)
+    ]
+
+
+def _generate_all_possible_triplets(labels: List[int]):
+    labels1 = np.expand_dims(labels, 1)
+    labels2 = np.expand_dims(labels, 0)
+    matches = (labels1 == labels2).astype(int)
+    diffs = matches ^ 1
+    np.fill_diagonal(matches, 0)
+    triplets = np.expand_dims(matches, 2) * np.expand_dims(diffs, 1)
+    idxes_anchor, idxes_pos, idxes_neg = np.where(triplets)
+    return list(zip(idxes_anchor, idxes_pos, idxes_neg))
 
 
 class SiameseMiner(BaseMiner):
@@ -17,10 +35,7 @@ class SiameseMiner(BaseMiner):
         :return: a pair of label indices and their label as tuple.
         """
         assert len(embeddings) == len(labels)
-        return [
-            (left[0], right[0], 1) if left[1] == right[1] else (left[0], right[0], -1)
-            for left, right in combinations(enumerate(labels), 2)
-        ]
+        return _generate_all_possible_pairs(labels)
 
 
 class TripletMiner(BaseMiner):
@@ -34,14 +49,7 @@ class TripletMiner(BaseMiner):
         :return: triplet of label indices follows the order of anchor, positive and negative.
         """
         assert len(embeddings) == len(labels)
-        labels1 = np.expand_dims(labels, 1)
-        labels2 = np.expand_dims(labels, 0)
-        matches = (labels1 == labels2).astype(int)
-        diffs = matches ^ 1
-        np.fill_diagonal(matches, 0)
-        triplets = np.expand_dims(matches, 2) * np.expand_dims(diffs, 1)
-        idxes_anchor, idxes_pos, idxes_neg = np.where(triplets)
-        return list(zip(idxes_anchor, idxes_pos, idxes_neg))
+        return _generate_all_possible_triplets(labels)
 
 
 class SiameseSessionMiner(BaseMiner):
@@ -52,9 +60,19 @@ class SiameseSessionMiner(BaseMiner):
 
         :param embeddings: embeddings from model, should be a list of Tensor objects.
         :param labels: labels of each embeddings, consist of session id and label.
+          the labels are either -1 or 1.
         :return: a pair of label indices and their label as tuple.
         """
+        rv = []
         assert len(embeddings) == len(labels)
+        for session, group in groupby(
+            sorted(labels, key=lambda x: x[0]), lambda x: x[0]
+        ):
+            session_labels = [item for _, item in group]
+            rv.extend(
+                _generate_all_possible_pairs(session_labels)
+            )  # all possible tuples in the session
+        return rv
 
 
 class TripletSessionMiner(BaseMiner):
@@ -67,4 +85,11 @@ class TripletSessionMiner(BaseMiner):
         :param labels: labels of each embeddings, consist of session id and label.
         :return: triplet of label indices follows the order of anchor, positive and negative.
         """
-        pass
+        rv = []
+        assert len(embeddings) == len(labels)
+        for session, group in groupby(
+            sorted(labels, key=lambda x: x[0]), lambda x: x[0]
+        ):
+            session_labels = [item for _, item in group]
+            rv.extend(_generate_all_possible_triplets(session_labels))
+        return rv

--- a/finetuner/tuner/pytorch/miner.py
+++ b/finetuner/tuner/pytorch/miner.py
@@ -92,22 +92,23 @@ class TripletSessionMiner(BaseMiner):
         labels_with_index = [item + (index,) for index, item in enumerate(labels)]
         sorted_labels_with_index = sorted(labels_with_index, key=lambda x: x[0])
         for session, group in groupby(sorted_labels_with_index, lambda x: x[0]):
-            anchor_pos_session_labels = []
-            anchor_pos_session_indices = []
-            neg_session_indices = []
-            for _, session_label, session_index in group:
-                if session_label >= 0:
-                    anchor_pos_session_labels.append(session_label)
-                    anchor_pos_session_indices.append(session_index)
-                else:
-                    neg_session_indices.append(session_index)
-            for anchor, pos in permutations(enumerate(anchor_pos_session_labels), 2):
-                for neg_idx in neg_session_indices:
-                    rv.append(
-                        (
-                            anchor_pos_session_indices[anchor[0]],
-                            anchor_pos_session_indices[pos[0]],
-                            neg_idx,
-                        )
-                    )
+            pass
+            # anchor_pos_session_labels = []
+            # anchor_pos_session_indices = []
+            # neg_session_indices = []
+            # for _, session_label, session_index in group:
+            #     if session_label >= 0:
+            #         anchor_pos_session_labels.append(session_label)
+            #         anchor_pos_session_indices.append(session_index)
+            #     else:
+            #         neg_session_indices.append(session_index)
+            # for anchor, pos in permutations(enumerate(anchor_pos_session_labels), 2):
+            #     for neg_idx in neg_session_indices:
+            #         rv.append(
+            #             (
+            #                 anchor_pos_session_indices[anchor[0]],
+            #                 anchor_pos_session_indices[pos[0]],
+            #                 neg_idx,
+            #             )
+            #         )
         return rv

--- a/finetuner/tuner/pytorch/miner.py
+++ b/finetuner/tuner/pytorch/miner.py
@@ -70,12 +70,10 @@ class SiameseSessionMiner(BaseMiner):
         for session, group in groupby(sorted_labels_with_index, lambda x: x[0]):
             _, session_labels, session_indices = zip(*group)
             pairs = _generate_all_possible_pairs(session_labels)
-            rv.extend(
-                [
+            for left_idx, right_idx, label in pairs:
+                rv.append(
                     (session_indices[left_idx], session_indices[right_idx], label)
-                    for left_idx, right_idx, label in pairs
-                ]
-            )
+                )
         return rv
 
 
@@ -96,14 +94,12 @@ class TripletSessionMiner(BaseMiner):
         for session, group in groupby(sorted_labels_with_index, lambda x: x[0]):
             _, session_labels, session_indices = zip(*group)
             triplets = _generate_all_possible_triplets(session_labels)
-            rv.extend(
-                [
+            for left_idx, middle_idx, right_idx in triplets:
+                rv.append(
                     (
                         session_indices[left_idx],
                         session_indices[middle_idx],
                         session_indices[right_idx],
                     )
-                    for left_idx, middle_idx, right_idx in triplets
-                ]
-            )
+                )
         return rv

--- a/finetuner/tuner/pytorch/miner.py
+++ b/finetuner/tuner/pytorch/miner.py
@@ -26,8 +26,8 @@ def _generate_all_possible_triplets(labels: List[int]):
 
 class SiameseMiner(BaseMiner):
     def mine(
-        self, embeddings: List[AnyTensor], labels: List[int]
-    ) -> List[Tuple[int, ...]]:
+        self, embeddings: AnyTensor, labels: List[int]
+    ) -> List[Tuple[int, int, int]]:
         """Generate tuples from input embeddings and labels.
 
         :param embeddings: embeddings from model, should be a list of Tensor objects.
@@ -40,8 +40,8 @@ class SiameseMiner(BaseMiner):
 
 class TripletMiner(BaseMiner):
     def mine(
-        self, embeddings: List[AnyTensor], labels: List[int]
-    ) -> List[Tuple[int, ...]]:
+        self, embeddings: AnyTensor, labels: List[int]
+    ) -> List[Tuple[int, int, int]]:
         """Generate triplets from input embeddings and labels.
 
         :param embeddings: embeddings from model, should be a list of Tensor objects.
@@ -54,8 +54,8 @@ class TripletMiner(BaseMiner):
 
 class SiameseSessionMiner(BaseMiner):
     def mine(
-        self, embeddings: List[AnyTensor], labels: List[Tuple[int, int]]
-    ) -> List[Tuple[int, ...]]:
+        self, embeddings: AnyTensor, labels: List[Tuple[int, int]]
+    ) -> List[Tuple[int, int, int]]:
         """Generate tuples from input embeddings and labels.
 
         :param embeddings: embeddings from model, should be a list of Tensor objects.
@@ -81,8 +81,8 @@ class SiameseSessionMiner(BaseMiner):
 
 class TripletSessionMiner(BaseMiner):
     def mine(
-        self, embeddings: List[AnyTensor], labels: List[Tuple[int, int]]
-    ) -> List[Tuple[int, ...]]:
+        self, embeddings: AnyTensor, labels: List[Tuple[int, int]]
+    ) -> List[Tuple[int, int, int]]:
         """Generate triplets from input embeddings and labels.
 
         :param embeddings: embeddings from model, should be a list of Tensor objects.

--- a/finetuner/tuner/pytorch/miner.py
+++ b/finetuner/tuner/pytorch/miner.py
@@ -67,11 +67,14 @@ class SiameseSessionMiner(BaseMiner):
             _, session_labels, session_indices = zip(*group)
             session_pairs = []
             for left, right in combinations(enumerate(session_labels), 2):
-                if (left[1] in [0, 1] and right[1] in [0, 1]) or (
-                    left[1] == -1 and right[1] == -1
-                ):
+                if left[1] in [0, 1] and right[1] in [0, 1]:
+                    # 0 represents for anchor, 1 for positive, they form positive pairs.
                     session_pairs.append((left[0], right[0], 1))
+                elif left[1] == -1 and right[1] == -1:
+                    # if both left and right are negatives, skip.
+                    continue
                 else:
+                    # one anchor or positive, one negative form a negative sample.
                     session_pairs.append((left[0], right[0], -1))
             for left_idx, right_idx, label in session_pairs:
                 rv.append(

--- a/finetuner/tuner/pytorch/miner.py
+++ b/finetuner/tuner/pytorch/miner.py
@@ -67,9 +67,7 @@ class SiameseSessionMiner(BaseMiner):
         rv = []
         labels_with_index = [item + (index,) for index, item in enumerate(labels)]
         sorted_labels_with_index = sorted(labels_with_index, key=lambda x: x[0])
-        for session, group in groupby(
-            sorted(sorted_labels_with_index, key=lambda x: x[0]), lambda x: x[0]
-        ):
+        for session, group in groupby(sorted_labels_with_index, lambda x: x[0]):
             _, session_labels, session_indices = zip(*group)
             pairs = _generate_all_possible_pairs(session_labels)
             rv.extend(
@@ -95,9 +93,7 @@ class TripletSessionMiner(BaseMiner):
         rv = []
         labels_with_index = [item + (index,) for index, item in enumerate(labels)]
         sorted_labels_with_index = sorted(labels_with_index, key=lambda x: x[0])
-        for session, group in groupby(
-            sorted(sorted_labels_with_index, key=lambda x: x[0]), lambda x: x[0]
-        ):
+        for session, group in groupby(sorted_labels_with_index, lambda x: x[0]):
             _, session_labels, session_indices = zip(*group)
             triplets = _generate_all_possible_triplets(session_labels)
             rv.extend(

--- a/finetuner/tuner/pytorch/miner.py
+++ b/finetuner/tuner/pytorch/miner.py
@@ -1,6 +1,6 @@
 import numpy as np
 from typing import List, Tuple
-from itertools import combinations, groupby
+from itertools import combinations, groupby, permutations
 
 from ..base import BaseMiner
 from ...helper import AnyTensor
@@ -96,10 +96,11 @@ class TripletSessionMiner(BaseMiner):
         sorted_labels_with_index = sorted(labels_with_index, key=lambda x: x[0])
         for session, group in groupby(sorted_labels_with_index, lambda x: x[0]):
             _, session_labels, session_indices = zip(*group)
-            for left, middle, right in combinations(enumerate(session_labels), 3):
+            for left, middle, right in permutations(enumerate(session_labels), 3):
                 neg_label_count = [left[1], middle[1], right[1]].count(-1)
                 # one and only one label is -1 means all rest greater or equal than 0
-                if neg_label_count == 1:
+                # and last element must be negative
+                if neg_label_count == 1 and right[1] == -1:
                     rv.append(
                         (
                             session_indices[left[0]],

--- a/finetuner/tuner/pytorch/miner.py
+++ b/finetuner/tuner/pytorch/miner.py
@@ -63,15 +63,17 @@ class SiameseSessionMiner(BaseMiner):
             _, session_labels, session_indices = zip(*group)
             session_pairs = []
             for left, right in combinations(enumerate(session_labels), 2):
-                if left[1] in [0, 1] and right[1] in [0, 1]:
+                if left[1] >= 0 and right[1] >= 0:
                     # 0 represents for anchor, 1 for positive, they form positive pairs.
                     session_pairs.append((left[0], right[0], 1))
-                elif left[1] == -1 and right[1] == -1:
-                    # if both left and right are negatives, skip.
-                    continue
-                else:
-                    # one anchor or positive, one negative form a negative sample.
+                elif (left[1] >= 0 and right[1] == -1) or (
+                    left[1] == -1 and right[1] >= 0
+                ):
+                    # one of the item is positive or anchor, another one is negative
                     session_pairs.append((left[0], right[0], -1))
+                else:
+                    # both are negatives
+                    continue
             for left_idx, right_idx, label in session_pairs:
                 rv.append(
                     (session_indices[left_idx], session_indices[right_idx], label)

--- a/finetuner/tuner/pytorch/miner.py
+++ b/finetuner/tuner/pytorch/miner.py
@@ -46,25 +46,25 @@ class TripletMiner(BaseMiner):
 
 class SiameseSessionMiner(BaseMiner):
     def mine(
-        self, embeddings: List[AnyTensor], labels: List[int]
+        self, embeddings: List[AnyTensor], labels: List[Tuple[int, int]]
     ) -> List[Tuple[int, ...]]:
         """Generate tuples from input embeddings and labels.
 
         :param embeddings: embeddings from model, should be a list of Tensor objects.
-        :param labels: labels of each embeddings, embeddings with same label indicates same class.
+        :param labels: labels of each embeddings, consist of session id and label.
         :return: a pair of label indices and their label as tuple.
         """
-        pass
+        assert len(embeddings) == len(labels)
 
 
 class TripletSessionMiner(BaseMiner):
     def mine(
-        self, embeddings: List[AnyTensor], labels: List[int]
+        self, embeddings: List[AnyTensor], labels: List[Tuple[int, int]]
     ) -> List[Tuple[int, ...]]:
         """Generate triplets from input embeddings and labels.
 
         :param embeddings: embeddings from model, should be a list of Tensor objects.
-        :param labels: labels of each embeddings, embeddings with same label indicates same class.
+        :param labels: labels of each embeddings, consist of session id and label.
         :return: triplet of label indices follows the order of anchor, positive and negative.
         """
         pass

--- a/finetuner/tuner/pytorch/miner.py
+++ b/finetuner/tuner/pytorch/miner.py
@@ -59,7 +59,7 @@ class SiameseSessionMiner(BaseMiner):
         rv = []
         labels_with_index = [item + (index,) for index, item in enumerate(labels)]
         sorted_labels_with_index = sorted(labels_with_index, key=lambda x: x[0])
-        for session, group in groupby(sorted_labels_with_index, lambda x: x[0]):
+        for _, group in groupby(sorted_labels_with_index, lambda x: x[0]):
             _, session_labels, session_indices = zip(*group)
             for left, right in combinations(enumerate(session_labels), 2):
                 if left[1] >= 0 and right[1] >= 0:
@@ -91,24 +91,23 @@ class TripletSessionMiner(BaseMiner):
         rv = []
         labels_with_index = [item + (index,) for index, item in enumerate(labels)]
         sorted_labels_with_index = sorted(labels_with_index, key=lambda x: x[0])
-        for session, group in groupby(sorted_labels_with_index, lambda x: x[0]):
-            pass
-            # anchor_pos_session_labels = []
-            # anchor_pos_session_indices = []
-            # neg_session_indices = []
-            # for _, session_label, session_index in group:
-            #     if session_label >= 0:
-            #         anchor_pos_session_labels.append(session_label)
-            #         anchor_pos_session_indices.append(session_index)
-            #     else:
-            #         neg_session_indices.append(session_index)
-            # for anchor, pos in permutations(enumerate(anchor_pos_session_labels), 2):
-            #     for neg_idx in neg_session_indices:
-            #         rv.append(
-            #             (
-            #                 anchor_pos_session_indices[anchor[0]],
-            #                 anchor_pos_session_indices[pos[0]],
-            #                 neg_idx,
-            #             )
-            #         )
+        for _, group in groupby(sorted_labels_with_index, lambda x: x[0]):
+            anchor_pos_session_labels = []
+            anchor_pos_session_indices = []
+            neg_session_indices = []
+            for _, session_label, session_index in group:
+                if session_label >= 0:
+                    anchor_pos_session_labels.append(session_label)
+                    anchor_pos_session_indices.append(session_index)
+                else:
+                    neg_session_indices.append(session_index)
+            for anchor, pos in permutations(enumerate(anchor_pos_session_labels), 2):
+                for neg_idx in neg_session_indices:
+                    rv.append(
+                        (
+                            anchor_pos_session_indices[anchor[0]],
+                            anchor_pos_session_indices[pos[0]],
+                            neg_idx,
+                        )
+                    )
         return rv

--- a/finetuner/tuner/pytorch/miner.py
+++ b/finetuner/tuner/pytorch/miner.py
@@ -100,8 +100,7 @@ class TripletSessionMiner(BaseMiner):
             _, session_labels, session_indices = zip(*group)
             for left, middle, right in permutations(enumerate(session_labels), 3):
                 neg_label_count = [left[1], middle[1], right[1]].count(-1)
-                # one and only one label is -1 means all rest greater or equal than 0
-                # and last element must be negative
+                # one and only one label is -1 and last element must be negative.
                 if neg_label_count == 1 and right[1] == -1:
                     rv.append(
                         (

--- a/finetuner/tuner/pytorch/miner.py
+++ b/finetuner/tuner/pytorch/miner.py
@@ -42,3 +42,29 @@ class TripletMiner(BaseMiner):
         triplets = np.expand_dims(matches, 2) * np.expand_dims(diffs, 1)
         idxes_anchor, idxes_pos, idxes_neg = np.where(triplets)
         return list(zip(idxes_anchor, idxes_pos, idxes_neg))
+
+
+class SiameseSessionMiner(BaseMiner):
+    def mine(
+        self, embeddings: List[AnyTensor], labels: List[int]
+    ) -> List[Tuple[int, ...]]:
+        """Generate tuples from input embeddings and labels.
+
+        :param embeddings: embeddings from model, should be a list of Tensor objects.
+        :param labels: labels of each embeddings, embeddings with same label indicates same class.
+        :return: a pair of label indices and their label as tuple.
+        """
+        pass
+
+
+class TripletSessionMiner(BaseMiner):
+    def mine(
+        self, embeddings: List[AnyTensor], labels: List[int]
+    ) -> List[Tuple[int, ...]]:
+        """Generate triplets from input embeddings and labels.
+
+        :param embeddings: embeddings from model, should be a list of Tensor objects.
+        :param labels: labels of each embeddings, embeddings with same label indicates same class.
+        :return: triplet of label indices follows the order of anchor, positive and negative.
+        """
+        pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,3 +5,9 @@ import tensorflow as tf
 @pytest.fixture(autouse=True)
 def clear_session():
     tf.keras.backend.clear_session()
+    config_proto = tf.ConfigProto()
+    config_proto.graph_options.rewrite_options.arithmetic_optimization = (
+        tf.core.protobuf.rewriter_config_pb2.RewriterConfig.OFF
+    )
+    session = tf.Session(config=config_proto)
+    tf.python.keras.backend.set_session(session)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,3 @@ import tensorflow as tf
 @pytest.fixture(autouse=True)
 def clear_session():
     tf.keras.backend.clear_session()
-    config_proto = tf.ConfigProto()
-    config_proto.graph_options.rewrite_options.arithmetic_optimization = (
-        tf.core.protobuf.rewriter_config_pb2.RewriterConfig.OFF
-    )
-    session = tf.Session(config=config_proto)
-    tf.python.keras.backend.set_session(session)

--- a/tests/unit/tuner/torch/test_miner.py
+++ b/tests/unit/tuner/torch/test_miner.py
@@ -99,7 +99,7 @@ def test_triplet_miner_given_insufficient_inputs(
 
 def test_siamese_session_miner(embeddings, session_labels, siamese_session_miner):
     rv = siamese_session_miner.mine(embeddings, session_labels)
-    assert len(rv) == 13
+    assert len(rv) == 12
     assert rv == [
         (0, 4, 1),
         (0, 5, -1),
@@ -111,7 +111,6 @@ def test_siamese_session_miner(embeddings, session_labels, siamese_session_miner
         (2, 3, -1),
         (2, 6, -1),
         (2, 7, 1),
-        (3, 6, 1),
         (3, 7, -1),
         (6, 7, -1),
     ]

--- a/tests/unit/tuner/torch/test_miner.py
+++ b/tests/unit/tuner/torch/test_miner.py
@@ -1,7 +1,12 @@
 import pytest
 import torch
 
-from finetuner.tuner.pytorch.miner import SiameseMiner, TripletMiner
+from finetuner.tuner.pytorch.miner import (
+    SiameseMiner,
+    TripletMiner,
+    SiameseSessionMiner,
+    TripletSessionMiner,
+)
 
 BATCH_SIZE = 8
 NUM_DIM = 10
@@ -18,6 +23,16 @@ def triplet_miner():
 
 
 @pytest.fixture
+def siamese_session_miner():
+    return SiameseSessionMiner()
+
+
+@pytest.fixture
+def triplet_session_miner():
+    return TripletSessionMiner()
+
+
+@pytest.fixture
 def embeddings():
     return [torch.rand(NUM_DIM) for _ in range(BATCH_SIZE)]
 
@@ -25,6 +40,11 @@ def embeddings():
 @pytest.fixture
 def labels():
     return [1, 3, 1, 3, 2, 4, 2, 4]
+
+
+@pytest.fixture
+def session_labels():
+    return [(1, 1), (2, -1), (2, 1), (1, -1), (3, -1), (3, 1), (3, -1), (3, -1)]
 
 
 def test_siamese_miner(embeddings, labels, siamese_miner):
@@ -74,4 +94,31 @@ def test_triplet_miner_given_insufficient_inputs(
     embeddings = embeddings[:cut_index]
     labels = labels[:cut_index]
     rv = list(siamese_miner.mine(embeddings, labels))
+    assert len(rv) == 0
+
+
+def test_siamese_session_miner(embeddings, session_labels, siamese_session_miner):
+    rv = siamese_session_miner.mine(embeddings, session_labels)
+    assert (
+        len(rv) == 8
+    )  # 1 pair with session 1, 1 pair with session 2, 6 pairs with session 3
+    for item in rv:
+        idx_left, idx_right, label = item
+        # find corresponded label idx
+        label_left = session_labels[idx_left]
+        label_right = session_labels[idx_right]
+        if label_left == label_right:
+            expected_label = 1
+        else:
+            expected_label = -1
+        assert label == expected_label
+
+
+@pytest.mark.parametrize('cut_index', [0, 1])
+def test_siamese_session_miner_given_insufficient_inputs(
+    embeddings, session_labels, siamese_session_miner, cut_index
+):
+    embeddings = embeddings[:cut_index]
+    session_labels = session_labels[:cut_index]
+    rv = list(siamese_session_miner.mine(embeddings, session_labels))
     assert len(rv) == 0

--- a/tests/unit/tuner/torch/test_miner.py
+++ b/tests/unit/tuner/torch/test_miner.py
@@ -128,7 +128,7 @@ def test_triplet_session_miner(embeddings, session_labels, triplet_session_miner
     rv = triplet_session_miner.mine(embeddings, session_labels)
     assert (
         len(rv) == 6
-    )  # session 1 and session 2 only have 2 data. session 3 generate 6 triplets.
+    )  # session 1 and session 2 only have 2 data points, generate 0 triplets. session 3 generate 6 triplets.
     for item in rv:
         idx_anchor, idx_pos, idx_neg = item
         # find corresponded label idx
@@ -142,3 +142,13 @@ def test_triplet_session_miner(embeddings, session_labels, triplet_session_miner
     all_anchors = {item[0] for item in rv}
     # assure only index 4, 6, 7 in anchor, 5 is a positive anchor do not have a positive pair
     assert {4, 6, 7}.issubset(all_anchors)
+
+
+@pytest.mark.parametrize('cut_index', [0, 1])
+def test_triplet_session_miner_given_insufficient_inputs(
+    embeddings, session_labels, triplet_session_miner, cut_index
+):
+    embeddings = embeddings[:cut_index]
+    session_labels = session_labels[:cut_index]
+    rv = list(triplet_session_miner.mine(embeddings, session_labels))
+    assert len(rv) == 0

--- a/tests/unit/tuner/torch/test_miner.py
+++ b/tests/unit/tuner/torch/test_miner.py
@@ -129,12 +129,19 @@ def test_triplet_session_miner(embeddings, session_labels, triplet_session_miner
     rv = triplet_session_miner.mine(embeddings, session_labels)
     assert rv == [
         (0, 4, 5),
+        (4, 0, 5),
         (1, 2, 3),
         (1, 2, 6),
-        (1, 3, 7),
-        (1, 6, 7),
-        (2, 3, 7),
-        (2, 6, 7),
+        (1, 7, 3),
+        (1, 7, 6),
+        (2, 1, 3),
+        (2, 1, 6),
+        (2, 7, 3),
+        (2, 7, 6),
+        (7, 1, 3),
+        (7, 1, 6),
+        (7, 2, 3),
+        (7, 2, 6),
     ]
 
 

--- a/tests/unit/tuner/torch/test_miner.py
+++ b/tests/unit/tuner/torch/test_miner.py
@@ -44,7 +44,7 @@ def labels():
 
 @pytest.fixture
 def session_labels():
-    return [(1, 1), (2, -1), (2, 1), (1, -1), (3, -1), (3, 1), (3, -1), (3, -1)]
+    return [(1, 1), (2, 1), (2, 0), (2, -1), (1, 0), (1, -1), (2, -1), (2, 1)]
 
 
 def test_siamese_miner(embeddings, labels, siamese_miner):
@@ -99,19 +99,22 @@ def test_triplet_miner_given_insufficient_inputs(
 
 def test_siamese_session_miner(embeddings, session_labels, siamese_session_miner):
     rv = siamese_session_miner.mine(embeddings, session_labels)
-    assert (
-        len(rv) == 8
-    )  # 1 pair with session 1, 1 pair with session 2, 6 pairs with session 3
-    for item in rv:
-        idx_left, idx_right, label = item
-        # find corresponded label idx
-        label_left = session_labels[idx_left]
-        label_right = session_labels[idx_right]
-        if label_left == label_right:
-            expected_label = 1
-        else:
-            expected_label = -1
-        assert label == expected_label
+    assert len(rv) == 13
+    assert rv == [
+        (0, 4, 1),
+        (0, 5, -1),
+        (4, 5, -1),
+        (1, 2, 1),
+        (1, 3, -1),
+        (1, 6, -1),
+        (1, 7, 1),
+        (2, 3, -1),
+        (2, 6, -1),
+        (2, 7, 1),
+        (3, 6, 1),
+        (3, 7, -1),
+        (6, 7, -1),
+    ]
 
 
 @pytest.mark.parametrize('cut_index', [0, 1])

--- a/tests/unit/tuner/torch/test_miner.py
+++ b/tests/unit/tuner/torch/test_miner.py
@@ -122,3 +122,23 @@ def test_siamese_session_miner_given_insufficient_inputs(
     session_labels = session_labels[:cut_index]
     rv = list(siamese_session_miner.mine(embeddings, session_labels))
     assert len(rv) == 0
+
+
+def test_triplet_session_miner(embeddings, session_labels, triplet_session_miner):
+    rv = triplet_session_miner.mine(embeddings, session_labels)
+    assert (
+        len(rv) == 6
+    )  # session 1 and session 2 only have 2 data. session 3 generate 6 triplets.
+    for item in rv:
+        idx_anchor, idx_pos, idx_neg = item
+        # find corresponded label idx
+        label_anchor = session_labels[idx_anchor]
+        label_pos = session_labels[idx_pos]
+        label_neg = session_labels[idx_neg]
+        # given ordered anchor, pos, neg,
+        # assure first two labels are identical, first third label is different
+        assert label_anchor == label_pos
+        assert label_anchor != label_neg
+    all_anchors = {item[0] for item in rv}
+    # assure only index 4, 6, 7 in anchor, 5 is a positive anchor do not have a positive pair
+    assert {4, 6, 7}.issubset(all_anchors)

--- a/tests/unit/tuner/torch/test_miner.py
+++ b/tests/unit/tuner/torch/test_miner.py
@@ -99,7 +99,6 @@ def test_triplet_miner_given_insufficient_inputs(
 
 def test_siamese_session_miner(embeddings, session_labels, siamese_session_miner):
     rv = siamese_session_miner.mine(embeddings, session_labels)
-    assert len(rv) == 12
     assert rv == [
         (0, 4, 1),
         (0, 5, -1),
@@ -128,22 +127,15 @@ def test_siamese_session_miner_given_insufficient_inputs(
 
 def test_triplet_session_miner(embeddings, session_labels, triplet_session_miner):
     rv = triplet_session_miner.mine(embeddings, session_labels)
-    assert (
-        len(rv) == 6
-    )  # session 1 and session 2 only have 2 data points, generate 0 triplets. session 3 generate 6 triplets.
-    for item in rv:
-        idx_anchor, idx_pos, idx_neg = item
-        # find corresponded label idx
-        label_anchor = session_labels[idx_anchor]
-        label_pos = session_labels[idx_pos]
-        label_neg = session_labels[idx_neg]
-        # given ordered anchor, pos, neg,
-        # assure first two labels are identical, first third label is different
-        assert label_anchor == label_pos
-        assert label_anchor != label_neg
-    all_anchors = {item[0] for item in rv}
-    # assure only index 4, 6, 7 in anchor, 5 is a positive anchor do not have a positive pair
-    assert {4, 6, 7}.issubset(all_anchors)
+    assert rv == [
+        (0, 4, 5),
+        (1, 2, 3),
+        (1, 2, 6),
+        (1, 3, 7),
+        (1, 6, 7),
+        (2, 3, 7),
+        (2, 6, 7),
+    ]
 
 
 @pytest.mark.parametrize('cut_index', [0, 1])


### PR DESCRIPTION
This PR extends the current `Miner` with `Session Miners`, generate all possible tuples/triplets w.r.t each session (anchor).