### PR TITLE
fix(tailor): fix to emebdding model

### DIFF
--- a/finetuner/tailor/paddle/__init__.py
+++ b/finetuner/tailor/paddle/__init__.py
@@ -111,7 +111,7 @@ class PaddleTailor(BaseTailor):
                 not output_shape
                 or len(output_shape) != 2
                 or not is_seq_int(output_shape)
-                or summary[layer]['cls_name'] in self._model.__class__.__name__
+                or summary[layer]['cls_name'] == self._model.__class__.__name__
             )
 
             if (

--- a/finetuner/tailor/pytorch/__init__.py
+++ b/finetuner/tailor/pytorch/__init__.py
@@ -105,7 +105,7 @@ class PytorchTailor(BaseTailor):
                 not output_shape
                 or len(output_shape) != 2
                 or not is_seq_int(output_shape)
-                or summary[layer]['cls_name'] in self._model.__class__.__name__
+                or summary[layer]['cls_name'] == self._model.__class__.__name__
             )
 
             if (


### PR DESCRIPTION
bug for `to_embedding_layer` (fixed for torch and paddle, tf works fine):

Reason: after attach a new layer to the end of model (user specify a different `output_dim`), `Paddle` and `Pytorch` added `_LinearAtLast` module, and `linear` layer will be considered as a part of `_LinearAtLast`, `is_embedding_layer` became `False`.

before: 
![image](https://user-images.githubusercontent.com/9794489/140918317-abb78b11-f9dc-4ef8-bc3c-ecdc22d20f39.png)


after:

![image](https://user-images.githubusercontent.com/9794489/140918258-0a6f5e9b-8505-4b31-9c12-7658fbcc3fa3.png)
