### PR TITLE
fix: make get_framework robust

### DIFF
--- a/finetuner/helper.py
+++ b/finetuner/helper.py
@@ -1,3 +1,4 @@
+import importlib.util
 from typing import (
     TypeVar,
     Sequence,
@@ -52,14 +53,29 @@ def get_framework(dnn_model: AnyDNN) -> str:
     :return: `keras`, `torch`, `paddle` or ValueError
 
     """
-    if 'keras' in dnn_model.__module__:
-        return 'keras'
-    elif 'torch' in dnn_model.__module__:  # note: cover torch and torchvision
-        return 'torch'
-    elif 'paddle' in dnn_model.__module__:
-        return 'paddle'
-    else:
+
+    framework = None
+
+    if importlib.util.find_spec('torch'):
+        import torch
+
+        if isinstance(dnn_model, torch.nn.Module):
+            framework = 'torch'
+    if framework is None and importlib.util.find_spec('torch'):
+        import paddle
+
+        if isinstance(dnn_model, paddle.nn.Layer):
+            framework = 'paddle'
+    if framework is None and importlib.util.find_spec('torch'):
+        from tensorflow import keras
+
+        if isinstance(dnn_model, keras.layers.Layer):
+            framework = 'keras'
+
+    if framework is None:
         raise ValueError(f'can not determine the backend of {dnn_model!r}')
+
+    return framework
 
 
 def is_seq_int(tp) -> bool:

--- a/finetuner/helper.py
+++ b/finetuner/helper.py
@@ -61,12 +61,12 @@ def get_framework(dnn_model: AnyDNN) -> str:
 
         if isinstance(dnn_model, torch.nn.Module):
             framework = 'torch'
-    if framework is None and importlib.util.find_spec('torch'):
+    if framework is None and importlib.util.find_spec('paddle'):
         import paddle
 
         if isinstance(dnn_model, paddle.nn.Layer):
             framework = 'paddle'
-    if framework is None and importlib.util.find_spec('torch'):
+    if framework is None and importlib.util.find_spec('tensorflow'):
         from tensorflow import keras
 
         if isinstance(dnn_model, keras.layers.Layer):

--- a/tests/unit/test_get_framework.py
+++ b/tests/unit/test_get_framework.py
@@ -1,0 +1,44 @@
+import paddle
+import torch
+from tensorflow import keras
+
+from finetuner.helper import get_framework
+
+
+def test_keras_base():
+    model = torch.nn.Linear(10, 10)
+    assert 'torch' == get_framework(model)
+
+
+def test_paddle_base():
+    model = paddle.nn.Linear(10, 10)
+    assert 'paddle' == get_framework(model)
+
+
+def test_torch_base():
+    model = keras.layers.Dense(10)
+    assert 'keras' == get_framework(model)
+
+
+def test_torch_custom():
+    class MyModel(torch.nn.Module):
+        pass
+
+    model = MyModel()
+    assert 'torch' == get_framework(model)
+
+
+def test_paddle_custom():
+    class MyModel(paddle.nn.Layer):
+        pass
+
+    model = MyModel()
+    assert 'paddle' == get_framework(model)
+
+
+def test_keras_custom():
+    class MyModel(keras.layers.Layer):
+        pass
+
+    model = MyModel()
+    assert 'keras' == get_framework(model)


### PR DESCRIPTION
Right now, `get_framework` is not robust, it fails against any kind of third party modules (ones created by user or from libraries like `transformers`). See this test below (fails with current `main`):

```python
def test_torch_custom():
    class MyModel(torch.nn.Module):
        pass

    model = MyModel()
    assert 'torch' == get_framework(model)
```

This PR fixes that by using `isinstance` for checking. However, this requires importing the corresponding framework (e.g. `torch`) - which can be a problem, as it would require all 3 frameworks to be installed just for inference. To circumvent this, a check is performed whether the framework is installed at all.

This is not ideal still - namely, if the user has all 3 frameworks installed (very rare case, but still), it can be the case that all 3 are imported just to perform this check. This is a disadvantage of what we are doing now - inference, instead of giving user the choice via exposing properly framework-specific class objects.