### PR TITLE
fix: docbot overflow and scrolling

### DIFF
--- a/docs/_static/docbot.css
+++ b/docs/_static/docbot.css
@@ -173,7 +173,7 @@
 }
 
 .ready .hidden-before-ready{
-  display: unset;
+  display: revert;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/docs/_static/docbot.js
+++ b/docs/_static/docbot.js
@@ -28,6 +28,7 @@ $(document).ready(function () {
         },
         methods: {
             notify_slack: function (question, answer, thumbup) {
+                const self = this;
                 $.ajax({
                     type: "POST",
                     url: app.slack_address,
@@ -45,10 +46,7 @@ $(document).ready(function () {
                     success: function (data, textStatus, jqXHR) {
                         // reset current question to empty
                         if (thumbup !== null) {
-                            Array.from(document.getElementsByClassName("answer-bubble")).slice(-1)[0].scrollIntoView({
-                                block: "nearest",
-                                inline: "nearest"
-                            });
+                            self.scrollToBottom();
                         }
                     },
                     error: function (request, status, error) {
@@ -67,6 +65,11 @@ $(document).ready(function () {
                 app.notify_slack(qa.question, qa.answer, val);
             },
             submit_q: function () {
+                if (app.is_busy) {
+                    return;
+                }
+                const self = this;
+                this.scrollToBottom();
                 app.is_busy = true;
                 app.is_conn_broken = false;
                 app.qa_pairs.push({ "question": app.cur_question, "rating": null });
@@ -91,12 +94,17 @@ $(document).ready(function () {
                     },
                     complete: function () {
                         app.is_busy = false;
-                        Array.from(document.getElementsByClassName("answer-bubble")).slice(-1)[0].scrollIntoView({
-                            block: "nearest",
-                            inline: "nearest"
-                        });
+                        self.scrollToBottom();
                     }
                 });
+            },
+            scrollToBottom() {
+                setTimeout(() => {
+                    Array.from(document.getElementsByClassName("qa-container")).pop().scrollIntoView({
+                        block: "end",
+                        inline: "nearest"
+                    });
+                }, 100);
             },
         }
     });


### PR DESCRIPTION
This fixes a bug in the previous patch that the doc-bot grows infinitely upon multiple questions and won't trigger a scroller.
Fixes the automatic scroll-to-bottom position.
Fixes multiple concurrent query when `enter` is pressed multiple times.