### PR TITLE
fix(docbot): feedback tooltip ui style

### DIFF
--- a/docs/_static/docbot.css
+++ b/docs/_static/docbot.css
@@ -151,6 +151,14 @@
   bottom: -20px;
   position: absolute;
   left: 20px;
+
+  display: flex;
+  justify-content: space-between;
+  width: calc(100% - 20px - 12px)
+}
+
+.answer-reference {
+  white-space: nowrap;
 }
 
 .answer-reference:after {

--- a/docs/_templates/docbot.html
+++ b/docs/_templates/docbot.html
@@ -56,7 +56,7 @@
                            target="_blank">Report</a>
                         <div v-if="qa.answer && !is_conn_broken && qa.answer.uri" class="feedback-tooltip sd-d-flex-row">
                             <a class="answer-reference" :href="root_url + qa.answer.uri">Source</a>
-                            <div class="sd-d-flex-row" style="margin-left: 40px">
+                            <div class="sd-d-flex-row">
                                 <div class="thumb-answer thumbup" v-show="qa.rating===null" style="margin: 0 6px" v-on:click="submit_rating(qa, true)">
                                     <svg aria-hidden="true" class="sd-octicon sd-octicon-thumbsup" height="1.0em"
                                          version="1.1" viewBox="0 0 16 16" width="1.0em">


### PR DESCRIPTION
This fixes the feedback tooltip broken issue when the answer is too short.
Although finetuner docbot rarely return short answers to get a buggy screenshot,
It's better to keep code the same with Jina doc.

From:
<img width="340" alt="CleanShot 2021-11-22 at 22 53 48@2x" src="https://user-images.githubusercontent.com/565869/142904848-c34f80a0-51a6-42fd-ad69-b45319638fdc.png">


To:
<img width="381" alt="CleanShot 2021-11-23 at 00 59 52@2x" src="https://user-images.githubusercontent.com/565869/142904867-ac3a53fa-8000-4ed7-becc-1f959fd5004d.png">

