### PR TITLE
feat(tailor): support freeze by layer names

### DIFF
--- a/finetuner/tailor/keras/__init__.py
+++ b/finetuner/tailor/keras/__init__.py
@@ -36,9 +36,7 @@ class KerasTailor(BaseTailor):
             output_shape = _get_output_shape(layer)
             input_shape = _get_input_shape(layer)
             is_embedding_layer = not (
-                not output_shape
-                or len(output_shape) != 2
-                or not isinstance(output_shape[-1], int)
+                not output_shape or not isinstance(output_shape[-1], int)
             )
 
             if not layer.built and not getattr(layer, '_is_graph_network', False):

--- a/finetuner/tailor/keras/__init__.py
+++ b/finetuner/tailor/keras/__init__.py
@@ -36,7 +36,9 @@ class KerasTailor(BaseTailor):
             output_shape = _get_output_shape(layer)
             input_shape = _get_input_shape(layer)
             is_embedding_layer = not (
-                not output_shape or not isinstance(output_shape[-1], int)
+                not output_shape
+                or len(output_shape) != 2
+                or not isinstance(output_shape[-1], int)
             )
 
             if not layer.built and not getattr(layer, '_is_graph_network', False):

--- a/finetuner/tailor/paddle/__init__.py
+++ b/finetuner/tailor/paddle/__init__.py
@@ -112,7 +112,6 @@ class PaddleTailor(BaseTailor):
             input_shape = summary[layer]['input_shape']
             is_embedding_layer = not (
                 not output_shape
-                or len(output_shape) != 2
                 or not is_seq_int(output_shape)
                 or summary[layer]['cls_name'] == self._model.__class__.__name__
             )

--- a/finetuner/tailor/paddle/__init__.py
+++ b/finetuner/tailor/paddle/__init__.py
@@ -112,6 +112,7 @@ class PaddleTailor(BaseTailor):
             input_shape = summary[layer]['input_shape']
             is_embedding_layer = not (
                 not output_shape
+                or len(output_shape) != 2
                 or not is_seq_int(output_shape)
                 or summary[layer]['cls_name'] == self._model.__class__.__name__
             )

--- a/finetuner/tailor/paddle/__init__.py
+++ b/finetuner/tailor/paddle/__init__.py
@@ -1,7 +1,7 @@
 import copy
 import warnings
 from collections import OrderedDict
-from typing import Optional, TYPE_CHECKING
+from typing import Optional, List, TYPE_CHECKING
 
 import numpy as np
 import paddle
@@ -141,6 +141,7 @@ class PaddleTailor(BaseTailor):
         layer_name: Optional[str] = None,
         output_dim: Optional[int] = None,
         freeze: bool = False,
+        freeze_layers: Optional[List[str]] = None,
     ) -> 'AnyDNN':
         """Convert a general model from :py:attr:`.model` to an embedding model.
 
@@ -148,13 +149,13 @@ class PaddleTailor(BaseTailor):
             will be removed. When set to ``None``, then the last layer listed in :py:attr:`.embedding_layers` will be used.
             To see all available names you can check ``name`` field of :py:attr:`.embedding_layers`.
         :param output_dim: the dimensionality of the embedding output.
-        :param freeze: if set, then freeze all weights of the original model.
+        :param freeze: if set, then freeze weights of a model. If :py:attr:`freeze_layers` is defined, only freeze layers in :py:attr:`freeze_layers`.
+        :param freeze_layers: if set, then freeze specific layers.
         :return: Converted embedding model.
         """
         model = copy.deepcopy(self._model)
-
+        _all_embed_layers = {l['name']: l for l in self.embedding_layers}
         if layer_name:
-            _all_embed_layers = {l['name']: l for l in self.embedding_layers}
             try:
                 _embed_layer = _all_embed_layers[layer_name]
             except KeyError as e:
@@ -165,7 +166,12 @@ class PaddleTailor(BaseTailor):
             # when not given, using the last layer
             _embed_layer = self.embedding_layers[-1]
 
-        if freeze:
+        if freeze and freeze_layers:
+            # freeze specific layers defined in `freeze_layers`
+            for layer_name, param in zip(_all_embed_layers, model.parameters()):
+                if layer_name in freeze_layers:
+                    param.trainable = False
+        if freeze and not freeze_layers:
             for param in model.parameters():
                 param.trainable = False
 

--- a/finetuner/tailor/pytorch/__init__.py
+++ b/finetuner/tailor/pytorch/__init__.py
@@ -106,7 +106,6 @@ class PytorchTailor(BaseTailor):
             input_shape = summary[layer]['input_shape']
             is_embedding_layer = not (
                 not output_shape
-                or len(output_shape) != 2
                 or not is_seq_int(output_shape)
                 or summary[layer]['cls_name'] == self._model.__class__.__name__
             )

--- a/finetuner/tailor/pytorch/__init__.py
+++ b/finetuner/tailor/pytorch/__init__.py
@@ -106,6 +106,7 @@ class PytorchTailor(BaseTailor):
             input_shape = summary[layer]['input_shape']
             is_embedding_layer = not (
                 not output_shape
+                or len(output_shape) != 2
                 or not is_seq_int(output_shape)
                 or summary[layer]['cls_name'] == self._model.__class__.__name__
             )

--- a/tests/unit/tailor/test_paddle.py
+++ b/tests/unit/tailor/test_paddle.py
@@ -175,6 +175,42 @@ def test_freeze(model, layer_name, input_size, input_dtype, freeze):
 
 
 @pytest.mark.parametrize(
+    'model, layer_name, input_size, input_dtype, freeze_layers',
+    [
+        ('dense_model', 10, (128,), 'float32', ['linear_1', 'linear_5']),
+        ('simple_cnn_model', 2, (1, 28, 28), 'float32', ['conv2d_1', 'maxpool2d_5']),
+        (
+            'vgg16_cnn_model',
+            4,
+            (3, 224, 224),
+            'float32',
+            ['conv2d_27', 'maxpool2d_31', 'adaptiveavgpool2d_32'],
+        ),
+        ('stacked_lstm', 10, (128,), 'int64', ['linear_layer_1', 'linear_layer_2']),
+        ('bidirectional_lstm', 5, (128,), 'int64', ['lastcell_3', 'linear_4']),
+    ],
+    indirect=['model'],
+)
+def test_freeze_given_freeze_layers(
+    model, layer_name, input_size, input_dtype, freeze_layers
+):
+    pytorch_tailor = PaddleTailor(
+        model=model,
+        input_size=input_size,
+        input_dtype=input_dtype,
+    )
+    model = pytorch_tailor.to_embedding_model(
+        freeze=True, output_dim=2, freeze_layers=freeze_layers
+    )
+    for layer, param in zip(pytorch_tailor.embedding_layers, model.parameters()):
+        layer_name = layer['name']
+        if layer_name in freeze_layers:
+            assert param.trainable == False
+        else:
+            assert param.trainable == True
+
+
+@pytest.mark.parametrize(
     'model, layer_name, input_size, input_, input_dtype, expected_output_shape',
     [
         ('dense_model', 'linear_7', (128,), (1, 128), 'float32', [1, 10]),


### PR DESCRIPTION
in this PR, we added a `freeze_layers` parameter as argument of `to_embedding_layer`, which takes a list of `str`, allow user to freeze model by specific layer names. If user didn't specify `freeze_layers` and `freeze` is `True`, we freeze all layers. 

we also lifted restriction on output dimensionality, to allow any layer of `embedding_layers` serve as feature extractor.

Next step:
1. flatten embedding layer if last layer is > 2d.
2. always attach a new output layer as defined by `output_dim`.