### PR TITLE
feat: add wandb logger

### DIFF
--- a/.github/requirements-cicd-gpu.txt
+++ b/.github/requirements-cicd-gpu.txt
@@ -5,3 +5,4 @@ torch==1.9.0
 torchvision==0.10.0
 scipy==1.7.1
 transformers==4.12.3
+wandb==0.12.7

--- a/.github/requirements-cicd.txt
+++ b/.github/requirements-cicd.txt
@@ -5,3 +5,4 @@ torch==1.9.0
 torchvision==0.10.0
 scipy==1.7.1
 transformers==4.12.3
+wandb==0.12.7

--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,6 @@ MyIndexer/
 MyMemMap/
 original/
 output/
+
+# Logging
+/wandb

--- a/finetuner/__init__.py
+++ b/finetuner/__init__.py
@@ -6,9 +6,10 @@ __version__ = '0.2.5'
 __default_tag_key__ = 'finetuner_label'
 
 # define the high-level API: fit()
-from typing import Optional, overload, TYPE_CHECKING, Tuple, Union
+from typing import List, Optional, overload, TYPE_CHECKING, Tuple, Union
 
 if TYPE_CHECKING:
+    from .tuner.callback import BaseCallback
     from .helper import (
         AnyDNN,
         AnyOptimizer,
@@ -33,6 +34,7 @@ def fit(
     preprocess_fn: Optional['PreprocFnType'] = None,
     collate_fn: Optional['CollateFnType'] = None,
     num_items_per_class: Optional[int] = None,
+    callbacks: Optional[List['BaseCallback']] = None,
 ) -> 'AnyDNN':
     ...
 
@@ -52,6 +54,7 @@ def fit(
     preprocess_fn: Optional['PreprocFnType'] = None,
     collate_fn: Optional['CollateFnType'] = None,
     num_items_per_class: Optional[int] = None,
+    callbacks: Optional[List['BaseCallback']] = None,
     to_embedding_model: bool = True,  #: below are tailor args
     input_size: Optional[Tuple[int, ...]] = None,
     input_dtype: str = 'float32',
@@ -77,6 +80,7 @@ def fit(
     preprocess_fn: Optional['PreprocFnType'] = None,
     collate_fn: Optional['CollateFnType'] = None,
     num_items_per_class: Optional[int] = None,
+    callbacks: Optional[List['BaseCallback']] = None,
     interactive: bool = True,  #: below are labeler args
     clear_labels_on_start: bool = False,
     port_expose: Optional[int] = None,
@@ -100,6 +104,7 @@ def fit(
     preprocess_fn: Optional['PreprocFnType'] = None,
     collate_fn: Optional['CollateFnType'] = None,
     num_items_per_class: Optional[int] = None,
+    callbacks: Optional[List['BaseCallback']] = None,
     interactive: bool = True,  #: below are labeler args
     clear_labels_on_start: bool = False,
     port_expose: Optional[int] = None,

--- a/finetuner/tuner/__init__.py
+++ b/finetuner/tuner/__init__.py
@@ -1,10 +1,11 @@
-from typing import Optional, Type, TYPE_CHECKING, Union
+from typing import List, Optional, Type, TYPE_CHECKING, Union
 
 from .base import BaseLoss
 from ..helper import get_framework
 
 if TYPE_CHECKING:
     from .base import BaseTuner
+    from .callback import BaseCallback
     from ..helper import (
         AnyDNN,
         AnyOptimizer,
@@ -44,6 +45,7 @@ def fit(
     optimizer: Optional['AnyOptimizer'] = None,
     learning_rate: float = 1e-3,
     device: str = 'cpu',
+    callbacks: Optional[List['BaseCallback']] = None,
     **kwargs,
 ):
     """Finetune the model on the training data.
@@ -74,10 +76,12 @@ def fit(
         ``learning_rate`` parameter.
     :param device: The device to which to move the model. Supported options are
         ``"cpu"`` and ``"cuda"`` (for GPU)
+    :param callbacks: A list of callbacks. The progress bar callback
+        will be pre-prended to this list.
     """
     ft = _get_tuner_class(embed_model)
 
-    ft(embed_model, loss=loss).fit(
+    ft(embed_model, loss=loss, callbacks=callbacks).fit(
         train_data,
         eval_data,
         epochs=epochs,

--- a/finetuner/tuner/base.py
+++ b/finetuner/tuner/base.py
@@ -1,8 +1,7 @@
 import abc
 from typing import TYPE_CHECKING, Generic, List, Optional, Tuple, Union
 
-from .callback.base import BaseCallback
-from .callback.progress_bar import ProgressBarCallback
+from .callback import BaseCallback, ProgressBarCallback
 from .dataset import ClassDataset, SessionDataset
 from .dataset.samplers import ClassSampler, SessionSampler
 from .miner.base import BaseMiner
@@ -64,8 +63,10 @@ class BaseTuner(abc.ABC, Generic[AnyDNN, AnyDataLoader, AnyOptimizer]):
         self._embed_model = embed_model
         self._loss = self._get_loss(loss)
 
+        print(callbacks)
         callbacks = callbacks or []
         self._callbacks = [ProgressBarCallback()] + callbacks
+        print(self._callbacks)
 
     @staticmethod
     def _get_batch_sampler(

--- a/finetuner/tuner/base.py
+++ b/finetuner/tuner/base.py
@@ -63,10 +63,8 @@ class BaseTuner(abc.ABC, Generic[AnyDNN, AnyDataLoader, AnyOptimizer]):
         self._embed_model = embed_model
         self._loss = self._get_loss(loss)
 
-        print(callbacks)
         callbacks = callbacks or []
         self._callbacks = [ProgressBarCallback()] + callbacks
-        print(self._callbacks)
 
     @staticmethod
     def _get_batch_sampler(

--- a/finetuner/tuner/callback/__init__.py
+++ b/finetuner/tuner/callback/__init__.py
@@ -1,0 +1,3 @@
+from .base import BaseCallback  # noqa: F401
+from .progress_bar import ProgressBarCallback  # noqa: F401
+from .wandb_logger import WandBLogger  # noqa: F401

--- a/finetuner/tuner/callback/progress_bar.py
+++ b/finetuner/tuner/callback/progress_bar.py
@@ -92,6 +92,10 @@ class ProgressBarCallback(BaseCallback):
             task_id=self.train_pbar_id, advance=1, metrics=self.train_loss_str
         )
 
+        from time import sleep
+
+        sleep(0.5)
+
     def on_val_begin(self, tuner: 'BaseTuner'):
         """
         Called at the start of the evaluation.
@@ -116,6 +120,10 @@ class ProgressBarCallback(BaseCallback):
         self.pbar.update(
             task_id=self.eval_pbar_id, advance=1, metrics=self.val_loss_str
         )
+
+        from time import sleep
+
+        sleep(0.5)
 
     def on_val_end(self, tuner: 'BaseTuner'):
         """

--- a/finetuner/tuner/callback/progress_bar.py
+++ b/finetuner/tuner/callback/progress_bar.py
@@ -92,10 +92,6 @@ class ProgressBarCallback(BaseCallback):
             task_id=self.train_pbar_id, advance=1, metrics=self.train_loss_str
         )
 
-        from time import sleep
-
-        sleep(0.5)
-
     def on_val_begin(self, tuner: 'BaseTuner'):
         """
         Called at the start of the evaluation.
@@ -120,10 +116,6 @@ class ProgressBarCallback(BaseCallback):
         self.pbar.update(
             task_id=self.eval_pbar_id, advance=1, metrics=self.val_loss_str
         )
-
-        from time import sleep
-
-        sleep(0.5)
 
     def on_val_end(self, tuner: 'BaseTuner'):
         """

--- a/finetuner/tuner/callback/wandb_logger.py
+++ b/finetuner/tuner/callback/wandb_logger.py
@@ -57,7 +57,10 @@ class WandBLogger(BaseCallback):
         Called at the end of the evaluation batch.
         """
         avg_loss = np.mean(self._val_losses)
-        self.wandb_logger.log(data={'val_loss': avg_loss}, step=self._train_step)
+        self.wandb_logger.log(
+            data={'val_loss': avg_loss, 'epoch': tuner.state.epoch},
+            step=self._train_step,
+        )
         self._val_losses = []
 
     def on_fit_end(self, tuner: 'BaseTuner'):

--- a/finetuner/tuner/callback/wandb_logger.py
+++ b/finetuner/tuner/callback/wandb_logger.py
@@ -1,0 +1,68 @@
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from .base import BaseCallback
+
+if TYPE_CHECKING:
+    from ..base import BaseTuner
+
+
+class WandBLogger(BaseCallback):
+    """
+    `Weights & Biases <https://wandb.ai/site>`_ logger to log metrics for training and
+    validation.
+
+    To use this logger, make sure to have a WandB account created, install the WandB
+    client (which you can do using ``pip install wandb``) and (using ``wandb login`` or
+    by setting the API key as environmental variable).
+    """
+
+    def __init__(self, **kwargs):
+        """Initialize the WandB logger
+
+        :param kwargs: Keyword arguments that are passed to ``wandb.init`` function.
+        """
+
+        import wandb
+
+        self.wandb_logger = wandb.init(**kwargs)
+
+        # For logging only train step matters (because for validation we don't care
+        # about individual steps)
+        self._train_step = 0
+
+        # Accumulator to gather all validation losses, to log average at the end
+        self._val_losses = []
+
+    def on_train_batch_end(self, tuner: 'BaseTuner'):
+        """
+        Called at the end of a training batch, after the backward pass.
+        """
+        self.wandb_logger.log(
+            data={'epoch': tuner.state.epoch, 'train_loss': tuner.state.current_loss},
+            step=self._train_step,
+        )
+        self._train_step += 1
+
+    def on_val_batch_end(self, tuner: 'BaseTuner'):
+        """
+        Called at the start of the evaluation batch, after the batch data has already
+        been loaded.
+        """
+        self._val_losses.append(tuner.state.current_loss)
+
+    def on_val_end(self, tuner: 'BaseTuner'):
+        """
+        Called at the end of the evaluation batch.
+        """
+        avg_loss = np.mean(self._val_losses)
+        self.wandb_logger.log(data={'val_loss': avg_loss}, step=self._train_step)
+        self._val_losses = []
+
+    def on_fit_end(self, tuner: 'BaseTuner'):
+        """
+        Called at the end of the ``fit`` method call, after finishing all the epochs.
+        """
+
+        self.wandb_logger.finish()

--- a/tests/unit/tuner/callback/test_wandb.py
+++ b/tests/unit/tuner/callback/test_wandb.py
@@ -1,0 +1,70 @@
+import pytest
+
+from finetuner.tuner.state import TunerState
+from finetuner.tuner.callback import WandBLogger
+
+import wandb
+
+
+class FakeTuner:
+    """Fake tuner since only an object with state property is needed for testing."""
+
+    state: TunerState
+
+
+class FakeWandB:
+    def __init__(self, **kwargs):
+        self.init_kwargs = kwargs
+
+    def log(self, data=None, step=None):
+        self.log_data = data
+        self.log_step = step
+
+
+@pytest.fixture
+def mocked_logger(monkeypatch):
+    monkeypatch.setattr(wandb, 'init', FakeWandB)
+
+
+def test_wandb_logger_init(mocked_logger):
+
+    tuner = FakeTuner()
+    tuner.state = TunerState(epoch=1, batch_index=2, current_loss=1.1)
+
+    logger = WandBLogger(project_name='my_project')
+
+    assert logger.wandb_logger.init_kwargs == {'project_name': 'my_project'}
+
+
+def test_wandb_logger_log_train(mocked_logger):
+
+    tuner = FakeTuner()
+    tuner.state = TunerState(epoch=1, batch_index=2, current_loss=1.1)
+
+    logger = WandBLogger()
+
+    logger.on_train_batch_end(tuner)
+    assert logger.wandb_logger.log_data == {'epoch': 1, 'train_loss': 1.1}
+    assert logger.wandb_logger.log_step == 0
+
+    logger.on_train_batch_end(tuner)
+    assert logger.wandb_logger.log_data == {'epoch': 1, 'train_loss': 1.1}
+    assert logger.wandb_logger.log_step == 1
+
+
+def test_wandb_logger_log_val(mocked_logger):
+
+    tuner = FakeTuner()
+    tuner.state = TunerState(epoch=1, batch_index=2, current_loss=1.1)
+
+    logger = WandBLogger()
+
+    logger.on_val_batch_end(tuner)
+
+    tuner.state.current_loss = 0.9
+    logger.on_val_batch_end(tuner)
+    assert logger._train_step == 0  # validation batch does not increase train step
+
+    logger.on_val_end(tuner)
+    assert logger.wandb_logger.log_data == {'val_loss': 1.0, 'epoch': 1}
+    assert logger.wandb_logger.log_step == 0


### PR DESCRIPTION
This adds support for logging with WandB - when we add learning rate scheduling (and proper evaluation) this will be expanded.

Here's how to use it

```python
import finetuner
from finetuner.tuner.callback import WandBLogger

finetuner.fit(
    embed_model,
    callbacks=[WandBLogger()],
    train_data=generate_fashion(num_total=2000),
    eval_data=generate_fashion(is_testset=True, num_total=1000),
)
```

Here's how the logs then look like in wandb

![image](https://user-images.githubusercontent.com/11489772/143889686-d51d9167-48ed-4ff2-a3b1-973c288eedb9.png)
