### PR TITLE
fix(test): fix flaky overfit test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,27 @@
+import random as python_random
+
+import numpy as np
+import paddle
 import pytest
 import tensorflow as tf
-import numpy as np
-from finetuner import __default_tag_key__
+import torch
 from jina import Document, DocumentArray
+
+from finetuner import __default_tag_key__
 
 
 @pytest.fixture(autouse=True)
 def clear_session():
     tf.keras.backend.clear_session()
+
+
+@pytest.fixture(autouse=True)
+def seed_session():
+    torch.manual_seed(42)
+    tf.random.set_seed(42)
+    paddle.seed(42)
+    np.random.seed(42)
+    python_random.seed(42)
 
 
 @pytest.fixture

--- a/tests/integration/torch/test_overfit.py
+++ b/tests/integration/torch/test_overfit.py
@@ -7,9 +7,6 @@ from finetuner.tuner.base import BaseLoss
 from finetuner.tuner.pytorch import PytorchTuner
 from finetuner.tuner.pytorch.losses import SiameseLoss, TripletLoss
 
-torch.manual_seed(42)
-random.seed(42)
-
 
 def check_distances(n_cls, vec_embedings, distance):
     # Compute pairwise distances between embeddings
@@ -85,11 +82,11 @@ def test_overfit_pytorch_session(
 @pytest.mark.parametrize(
     "n_cls,dim,n_epochs,loss,distance",
     [
-        (5, 10, 50, TripletLoss, 'euclidean'),
-        (5, 10, 100, TripletLoss, 'cosine'),
+        # (5, 10, 50, TripletLoss, 'euclidean'),
+        # (5, 10, 100, TripletLoss, 'cosine'),
         # Siamese needs more time to converge
         (5, 10, 100, SiameseLoss, 'euclidean'),
-        (5, 10, 100, SiameseLoss, 'cosine'),
+        # (5, 10, 100, SiameseLoss, 'cosine'),
     ],
 )
 def test_overfit_pytorch_class(

--- a/tests/integration/torch/test_overfit.py
+++ b/tests/integration/torch/test_overfit.py
@@ -1,10 +1,14 @@
 import pytest
 import torch
+import random
 from scipy.spatial.distance import pdist, squareform
 
 from finetuner.tuner.base import BaseLoss
 from finetuner.tuner.pytorch import PytorchTuner
 from finetuner.tuner.pytorch.losses import SiameseLoss, TripletLoss
+
+torch.manual_seed(42)
+random.seed(42)
 
 
 def check_distances(n_cls, vec_embedings, distance):

--- a/tests/integration/torch/test_overfit.py
+++ b/tests/integration/torch/test_overfit.py
@@ -1,6 +1,5 @@
 import pytest
 import torch
-import random
 from scipy.spatial.distance import pdist, squareform
 
 from finetuner.tuner.base import BaseLoss

--- a/tests/integration/torch/test_overfit.py
+++ b/tests/integration/torch/test_overfit.py
@@ -82,11 +82,11 @@ def test_overfit_pytorch_session(
 @pytest.mark.parametrize(
     "n_cls,dim,n_epochs,loss,distance",
     [
-        # (5, 10, 50, TripletLoss, 'euclidean'),
-        # (5, 10, 100, TripletLoss, 'cosine'),
+        (5, 10, 50, TripletLoss, 'euclidean'),
+        (5, 10, 100, TripletLoss, 'cosine'),
         # Siamese needs more time to converge
         (5, 10, 100, SiameseLoss, 'euclidean'),
-        # (5, 10, 100, SiameseLoss, 'cosine'),
+        (5, 10, 100, SiameseLoss, 'cosine'),
     ],
 )
 def test_overfit_pytorch_class(


### PR DESCRIPTION
Without setting manual seed, in each test runs
- Batch sampler gives different batches
- Model fine-tuned reports different embedding because the weights initialise are always random

This causes the embeddings to be different each time and thus test is flaky

Closes issue #252