### PR TITLE
feat: add multiprocessing dataloading

### DIFF
--- a/finetuner/__init__.py
+++ b/finetuner/__init__.py
@@ -41,6 +41,7 @@ def fit(
     collate_fn: Optional['CollateFnType'] = None,
     num_items_per_class: Optional[int] = None,
     callbacks: Optional[List['BaseCallback']] = None,
+    num_workers: int = 0,
 ) -> 'AnyDNN':
     ...
 
@@ -66,6 +67,7 @@ def fit(
     collate_fn: Optional['CollateFnType'] = None,
     num_items_per_class: Optional[int] = None,
     callbacks: Optional[List['BaseCallback']] = None,
+    num_workers: int = 0,
     to_embedding_model: bool = True,  #: below are tailor args
     input_size: Optional[Tuple[int, ...]] = None,
     input_dtype: str = 'float32',
@@ -97,6 +99,7 @@ def fit(
     collate_fn: Optional['CollateFnType'] = None,
     num_items_per_class: Optional[int] = None,
     callbacks: Optional[List['BaseCallback']] = None,
+    num_workers: int = 0,
     interactive: bool = True,  #: below are labeler args
     clear_labels_on_start: bool = False,
     port_expose: Optional[int] = None,
@@ -126,6 +129,7 @@ def fit(
     collate_fn: Optional['CollateFnType'] = None,
     num_items_per_class: Optional[int] = None,
     callbacks: Optional[List['BaseCallback']] = None,
+    num_workers: int = 0,
     interactive: bool = True,  #: below are labeler args
     clear_labels_on_start: bool = False,
     port_expose: Optional[int] = None,

--- a/finetuner/tuner/__init__.py
+++ b/finetuner/tuner/__init__.py
@@ -90,7 +90,7 @@ def fit(
         will be pre-prended to this list.
     :param num_workers: Number of workers used for loading the data.
 
-        This works onlywith Pytorch and Paddle Paddle, and has no effect when using
+        This works only with Pytorch and Paddle Paddle, and has no effect when using
         a Keras model.
     """
     ft = _get_tuner_class(embed_model)

--- a/finetuner/tuner/__init__.py
+++ b/finetuner/tuner/__init__.py
@@ -52,6 +52,7 @@ def fit(
     scheduler_step: str = 'batch',
     device: str = 'cpu',
     callbacks: Optional[List['BaseCallback']] = None,
+    num_workers: int = 0,
     **kwargs,
 ):
     """Finetune the model on the training data.
@@ -87,6 +88,10 @@ def fit(
         ``"cpu"`` and ``"cuda"`` (for GPU)
     :param callbacks: A list of callbacks. The progress bar callback
         will be pre-prended to this list.
+    :param num_workers: Number of workers used for loading the data.
+
+        This works onlywith Pytorch and Paddle Paddle, and has no effect when using
+        a Keras model.
     """
     ft = _get_tuner_class(embed_model)
 

--- a/finetuner/tuner/base.py
+++ b/finetuner/tuner/base.py
@@ -178,6 +178,9 @@ class BaseTuner(abc.ABC, Generic[AnyDNN, AnyDataLoader, AnyOptimizer, AnySchedul
         :param num_items_per_class: Number of items from a single class to include in
             the batch. Only relevant for class datasets
         :param num_workers: Number of workers used for loading the data.
+
+            This works onlywith Pytorch and Paddle Paddle, and has no effect when using
+            a Keras model.
         """
 
     @abc.abstractmethod

--- a/finetuner/tuner/base.py
+++ b/finetuner/tuner/base.py
@@ -116,6 +116,7 @@ class BaseTuner(abc.ABC, Generic[AnyDNN, AnyDataLoader, AnyOptimizer]):
         device: str = 'cpu',
         preprocess_fn: Optional['PreprocFnType'] = None,
         collate_fn: Optional['CollateFnType'] = None,
+        num_workers: int = 0,
         **kwargs,
     ):
         """Finetune the model on the training data.
@@ -139,6 +140,7 @@ class BaseTuner(abc.ABC, Generic[AnyDNN, AnyDataLoader, AnyOptimizer]):
             provide a custom optimizer, this learning rate will not apply.
         :param device: The device to which to move the model. Supported options are
             ``"cpu"`` and ``"cuda"`` (for GPU)
+        :param num_workers: Number of workers used for loading the data.
         """
 
     @abc.abstractmethod
@@ -160,6 +162,7 @@ class BaseTuner(abc.ABC, Generic[AnyDNN, AnyDataLoader, AnyOptimizer]):
         num_items_per_class: Optional[int] = None,
         preprocess_fn: Optional['PreprocFnType'] = None,
         collate_fn: Optional['CollateFnType'] = None,
+        num_workers: int = 0,
     ) -> AnyDataLoader:
         """Get framework specific data loader from the input data."""
         ...

--- a/finetuner/tuner/base.py
+++ b/finetuner/tuner/base.py
@@ -179,7 +179,7 @@ class BaseTuner(abc.ABC, Generic[AnyDNN, AnyDataLoader, AnyOptimizer, AnySchedul
             the batch. Only relevant for class datasets
         :param num_workers: Number of workers used for loading the data.
 
-            This works onlywith Pytorch and Paddle Paddle, and has no effect when using
+            This works only with Pytorch and Paddle Paddle, and has no effect when using
             a Keras model.
         """
 

--- a/finetuner/tuner/dataset/base.py
+++ b/finetuner/tuner/dataset/base.py
@@ -12,9 +12,6 @@ from typing import (
 
 import numpy as np
 
-if TYPE_CHECKING:
-    from finetuner.helper import T
-
 AnyLabel = TypeVar('AnyLabel')
 
 
@@ -23,25 +20,16 @@ class BaseSampler(abc.ABC):
         if batch_size <= 0:
             raise ValueError('batch_size must be a positive integer')
 
-        self._labels = labels
-        self._batch_size = batch_size
-        self._batches = []
-        self._index = 0
+        self._prepare_batches()
 
-    def __iter__(self: 'T') -> Iterator[List[int]]:
+    def __iter__(self) -> Iterator[List[int]]:
         yield from self._batches
 
         # After batches are exhausted, recreate
         self._prepare_batches()
 
     def __len__(self) -> int:
-        return len(self.batches)
-
-    @property
-    def batches(self):
-        if self._index == 0:
-            self._prepare_batches()
-        return self._batches
+        return len(self._batches)
 
     @abc.abstractmethod
     def _prepare_batches(self) -> None:

--- a/finetuner/tuner/dataset/base.py
+++ b/finetuner/tuner/dataset/base.py
@@ -1,5 +1,14 @@
 import abc
-from typing import TYPE_CHECKING, List, Generic, Tuple, Union, TypeVar, Sequence
+from typing import (
+    TYPE_CHECKING,
+    List,
+    Generic,
+    Iterator,
+    Tuple,
+    Union,
+    TypeVar,
+    Sequence,
+)
 
 import numpy as np
 
@@ -19,17 +28,11 @@ class BaseSampler(abc.ABC):
         self._batches = []
         self._index = 0
 
-    def __iter__(self: 'T') -> 'T':
-        return self
+    def __iter__(self: 'T') -> Iterator[List[int]]:
+        yield from self._batches
 
-    def __next__(self) -> List[int]:
-        if self._index == len(self):
-            self._index = 0
-            raise StopIteration
-
-        b = self.batches[self._index]
-        self._index += 1
-        return b
+        # After batches are exhausted, recreate
+        self._prepare_batches()
 
     def __len__(self) -> int:
         return len(self.batches)

--- a/finetuner/tuner/dataset/samplers.py
+++ b/finetuner/tuner/dataset/samplers.py
@@ -136,6 +136,7 @@ class SessionSampler(BaseSampler):
             sessions which is given by ``labels``.
         """
 
+        self._batch_size = batch_size
         self._shuffle = shuffle
         # The locations and types of labels for each session
         self._sessions = defaultdict(list)

--- a/finetuner/tuner/keras/__init__.py
+++ b/finetuner/tuner/keras/__init__.py
@@ -31,6 +31,7 @@ class KerasTuner(BaseTuner[tf.keras.layers.Layer, KerasSequenceAdapter, Optimize
         preprocess_fn: Optional['PreprocFnType'] = None,
         collate_fn: Optional['CollateFnType'] = None,
         num_items_per_class: Optional[int] = None,
+        num_workers: int = 1,
     ) -> KerasSequenceAdapter:
         """Get the dataloader for the dataset
 
@@ -53,7 +54,7 @@ class KerasTuner(BaseTuner[tf.keras.layers.Layer, KerasSequenceAdapter, Optimize
             dataset=dataset, batch_sampler=batch_sampler, collate_fn=collate_fn
         )
 
-        adapter = KerasSequenceAdapter(sequence)
+        adapter = KerasSequenceAdapter(sequence, workers=num_workers)
         return adapter
 
     def _get_default_optimizer(self, learning_rate: float) -> Optimizer:

--- a/finetuner/tuner/keras/__init__.py
+++ b/finetuner/tuner/keras/__init__.py
@@ -35,7 +35,7 @@ class KerasTuner(
         preprocess_fn: Optional['PreprocFnType'] = None,
         collate_fn: Optional['CollateFnType'] = None,
         num_items_per_class: Optional[int] = None,
-        num_workers: int = 1,
+        num_workers: int = 0,
     ) -> KerasSequenceAdapter:
         """Get the dataloader for the dataset
 
@@ -58,9 +58,7 @@ class KerasTuner(
             dataset=dataset, batch_sampler=batch_sampler, collate_fn=collate_fn
         )
 
-        adapter = KerasSequenceAdapter(
-            sequence, workers=num_workers, use_multiprocessing=num_workers > 1
-        )
+        adapter = KerasSequenceAdapter(sequence)
         return adapter
 
     def _move_model_to_device(self):

--- a/finetuner/tuner/keras/__init__.py
+++ b/finetuner/tuner/keras/__init__.py
@@ -58,7 +58,9 @@ class KerasTuner(
             dataset=dataset, batch_sampler=batch_sampler, collate_fn=collate_fn
         )
 
-        adapter = KerasSequenceAdapter(sequence, workers=num_workers)
+        adapter = KerasSequenceAdapter(
+            sequence, workers=num_workers, use_multiprocessing=num_workers > 1
+        )
         return adapter
 
     def _move_model_to_device(self):

--- a/finetuner/tuner/paddle/__init__.py
+++ b/finetuner/tuner/paddle/__init__.py
@@ -44,6 +44,7 @@ class PaddleTuner(BaseTuner[nn.Layer, DataLoader, Optimizer]):
         preprocess_fn: Optional['PreprocFnType'] = None,
         collate_fn: Optional['CollateFnType'] = None,
         num_items_per_class: Optional[int] = None,
+        num_workers: int = 0,
     ) -> DataLoader:
         """Get the dataloader for the dataset"""
 
@@ -69,7 +70,10 @@ class PaddleTuner(BaseTuner[nn.Layer, DataLoader, Optimizer]):
             num_items_per_class=num_items_per_class,
         )
         data_loader = DataLoader(
-            dataset=dataset, batch_sampler=batch_sampler, collate_fn=collate_fn_all
+            dataset=dataset,
+            batch_sampler=batch_sampler,
+            collate_fn=collate_fn_all,
+            num_workers=num_workers,
         )
 
         return data_loader
@@ -134,6 +138,7 @@ class PaddleTuner(BaseTuner[nn.Layer, DataLoader, Optimizer]):
         device: str = 'cpu',
         preprocess_fn: Optional['PreprocFnType'] = None,
         collate_fn: Optional['CollateFnType'] = None,
+        num_workers: int = 0,
         **kwargs,
     ):
         """Finetune the model on the training data.
@@ -156,6 +161,7 @@ class PaddleTuner(BaseTuner[nn.Layer, DataLoader, Optimizer]):
             provide a custom optimizer, this learning rate will not apply.
         :param device: The device to which to move the model. Supported options are
             ``"cpu"`` and ``"cuda"`` (for GPU)
+        :param num_workers: Number of workers used for loading the data.
         """
         # Get dataloaders
         train_dl = self._get_data_loader(
@@ -165,6 +171,7 @@ class PaddleTuner(BaseTuner[nn.Layer, DataLoader, Optimizer]):
             shuffle=True,
             preprocess_fn=preprocess_fn,
             collate_fn=collate_fn,
+            num_workers=num_workers,
         )
         if eval_data:
             eval_dl = self._get_data_loader(
@@ -174,6 +181,7 @@ class PaddleTuner(BaseTuner[nn.Layer, DataLoader, Optimizer]):
                 shuffle=False,
                 preprocess_fn=preprocess_fn,
                 collate_fn=collate_fn,
+                num_workers=num_workers,
             )
 
         # Place model on device

--- a/finetuner/tuner/pytorch/__init__.py
+++ b/finetuner/tuner/pytorch/__init__.py
@@ -44,6 +44,7 @@ class PytorchTuner(BaseTuner[nn.Module, DataLoader, Optimizer]):
         preprocess_fn: Optional['PreprocFnType'] = None,
         collate_fn: Optional['CollateFnType'] = None,
         num_items_per_class: Optional[int] = None,
+        num_workers: int = 0,
     ) -> DataLoader:
         """ Get the dataloader for the dataset"""
 
@@ -69,7 +70,10 @@ class PytorchTuner(BaseTuner[nn.Module, DataLoader, Optimizer]):
             num_items_per_class=num_items_per_class,
         )
         data_loader = DataLoader(
-            dataset=dataset, batch_sampler=batch_sampler, collate_fn=collate_fn_all
+            dataset=dataset,
+            batch_sampler=batch_sampler,
+            collate_fn=collate_fn_all,
+            num_workers=num_workers,
         )
 
         return data_loader
@@ -133,6 +137,7 @@ class PytorchTuner(BaseTuner[nn.Module, DataLoader, Optimizer]):
         device: str = 'cpu',
         preprocess_fn: Optional['PreprocFnType'] = None,
         collate_fn: Optional['CollateFnType'] = None,
+        num_workers: int = 0,
         **kwargs,
     ):
         """Finetune the model on the training data.
@@ -155,6 +160,7 @@ class PytorchTuner(BaseTuner[nn.Module, DataLoader, Optimizer]):
             provide a custom optimizer, this learning rate will not apply.
         :param device: The device to which to move the model. Supported options are
             ``"cpu"`` and ``"cuda"`` (for GPU)
+        :param num_workers: Number of workers used for loading the data.
         """
         # Get dataloaders
         train_dl = self._get_data_loader(
@@ -164,6 +170,7 @@ class PytorchTuner(BaseTuner[nn.Module, DataLoader, Optimizer]):
             shuffle=True,
             preprocess_fn=preprocess_fn,
             collate_fn=collate_fn,
+            num_workers=num_workers,
         )
         if eval_data:
             eval_dl = self._get_data_loader(
@@ -173,6 +180,7 @@ class PytorchTuner(BaseTuner[nn.Module, DataLoader, Optimizer]):
                 shuffle=False,
                 preprocess_fn=preprocess_fn,
                 collate_fn=collate_fn,
+                num_workers=num_workers,
             )
 
         # Place model on device

--- a/tests/integration/keras/test_num_workers.py
+++ b/tests/integration/keras/test_num_workers.py
@@ -1,0 +1,33 @@
+import numpy as np
+import pytest
+import tensorflow as tf
+
+from finetuner.tuner.keras import KerasTuner
+
+
+@pytest.mark.parametrize('num_workers,expected_batch_time', [(1, 4), (2, 2), (4, 1)])
+def test_multiple_workers(
+    num_workers,
+    expected_batch_time,
+    generate_random_data,
+    multi_workers_preprocess_fn,
+    multi_workers_callback,
+):
+    data = generate_random_data(20, 2, 2)
+    model = tf.keras.Sequential(
+        [tf.keras.layers.Flatten(), tf.keras.layers.Dense(2, activation='relu')]
+    )
+    tuner = KerasTuner(model, callbacks=[multi_workers_callback])
+
+    tuner.fit(
+        data,
+        epochs=1,
+        batch_size=4,
+        num_items_per_class=2,
+        num_workers=num_workers,
+        preprocess_fn=multi_workers_preprocess_fn,
+    )
+
+    np.testing.assert_almost_equal(
+        np.mean(multi_workers_callback.batch_times), expected_batch_time, decimal=1
+    )

--- a/tests/integration/keras/test_num_workers.py
+++ b/tests/integration/keras/test_num_workers.py
@@ -5,7 +5,7 @@ import tensorflow as tf
 from finetuner.tuner.keras import KerasTuner
 
 
-@pytest.mark.parametrize('num_workers,expected_batch_time', [(1, 4), (2, 2), (4, 1)])
+@pytest.mark.parametrize('num_workers,expected_batch_time', [(1, 4)])
 def test_multiple_workers(
     num_workers,
     expected_batch_time,
@@ -13,6 +13,36 @@ def test_multiple_workers(
     multi_workers_preprocess_fn,
     multi_workers_callback,
 ):
+    data = generate_random_data(20, 2, 2)
+    model = tf.keras.Sequential(
+        [tf.keras.layers.Flatten(), tf.keras.layers.Dense(2, activation='relu')]
+    )
+    tuner = KerasTuner(model, callbacks=[multi_workers_callback])
+
+    tuner.fit(
+        data,
+        epochs=1,
+        batch_size=4,
+        num_items_per_class=2,
+        num_workers=num_workers,
+        preprocess_fn=multi_workers_preprocess_fn,
+    )
+
+    np.testing.assert_almost_equal(
+        np.mean(multi_workers_callback.batch_times), expected_batch_time, decimal=1
+    )
+
+
+@pytest.mark.xfail
+@pytest.mark.parametrize('num_workers,expected_batch_time', [(2, 2), (4, 1)])
+def test_multiple_workers_fail(
+    num_workers,
+    expected_batch_time,
+    generate_random_data,
+    multi_workers_preprocess_fn,
+    multi_workers_callback,
+):
+    """Multi-processing of workers does not work with keras"""
     data = generate_random_data(20, 2, 2)
     model = tf.keras.Sequential(
         [tf.keras.layers.Flatten(), tf.keras.layers.Dense(2, activation='relu')]

--- a/tests/integration/paddle/test_num_workers.py
+++ b/tests/integration/paddle/test_num_workers.py
@@ -1,0 +1,34 @@
+import numpy as np
+import pytest
+import paddle
+
+from finetuner.tuner.paddle import PaddleTuner
+
+
+@pytest.mark.parametrize(
+    'num_workers,expected_batch_time', [(0, 4), (1, 4), (2, 2), (4, 1)]
+)
+def test_multiple_workers(
+    num_workers,
+    expected_batch_time,
+    generate_random_data,
+    multi_workers_preprocess_fn,
+    multi_workers_callback,
+):
+    data = generate_random_data(20, 2, 2)
+    model = paddle.nn.Linear(2, 2)
+
+    tuner = PaddleTuner(model, callbacks=[multi_workers_callback])
+
+    tuner.fit(
+        data,
+        epochs=1,
+        batch_size=4,
+        num_items_per_class=2,
+        num_workers=num_workers,
+        preprocess_fn=multi_workers_preprocess_fn,
+    )
+
+    np.testing.assert_almost_equal(
+        np.mean(multi_workers_callback.batch_times), expected_batch_time, decimal=1
+    )

--- a/tests/integration/torch/test_num_workers.py
+++ b/tests/integration/torch/test_num_workers.py
@@ -1,0 +1,34 @@
+import numpy as np
+import pytest
+import torch
+
+from finetuner.tuner.pytorch import PytorchTuner
+
+
+@pytest.mark.parametrize(
+    'num_workers,expected_batch_time', [(0, 5), (1, 4), (2, 2), (4, 1)]
+)
+def test_multiple_workers(
+    num_workers,
+    expected_batch_time,
+    generate_random_data,
+    multi_workers_preprocess_fn,
+    multi_workers_callback,
+):
+    data = generate_random_data(20, 2, 2)
+    model = torch.nn.Linear(2, 2)
+
+    tuner = PytorchTuner(model, callbacks=[multi_workers_callback])
+
+    tuner.fit(
+        data,
+        epochs=1,
+        batch_size=4,
+        num_items_per_class=2,
+        num_workers=num_workers,
+        preprocess_fn=multi_workers_preprocess_fn,
+    )
+
+    np.testing.assert_almost_equal(
+        np.mean(multi_workers_callback.batch_times), expected_batch_time, decimal=1
+    )


### PR DESCRIPTION
- [x] torch
- [x] paddle
- [x] ~~keras~~ - could not get keras to work with passthrough of `workers`, (and `multiprocessing`, etc.). By default Keras already behaves as if it has a (single) background process loading data - leaving it at that for now
- [x] tests (how?)