### PR TITLE
fix: evaluation imports imports to reflect new code structure

### DIFF
--- a/finetuner/tuner/evaluation.py
+++ b/finetuner/tuner/evaluation.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, Optional, List, Dict, Tuple
 from jina import Document, DocumentArray
-from jina.math.evaluation import (
+from jina.docarray.evaluation import (
     r_precision,
     precision_at_k,
     recall_at_k,

--- a/finetuner/tuner/evaluation.py
+++ b/finetuner/tuner/evaluation.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, Optional, List, Dict, Tuple
 from jina import Document, DocumentArray
-from docarray.evaluation import (
+from docarray.math.evaluation import (
     r_precision,
     precision_at_k,
     recall_at_k,

--- a/finetuner/tuner/evaluation.py
+++ b/finetuner/tuner/evaluation.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, Optional, List, Dict, Tuple
 from jina import Document, DocumentArray
-from jina.docarray.evaluation import (
+from docarray.evaluation import (
     r_precision,
     precision_at_k,
     recall_at_k,

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     long_description_content_type='text/markdown',
     zip_safe=False,
     setup_requires=['setuptools>=18.0', 'wheel'],
-    install_requires=['jina>=2.4.9', 'matplotlib'],
+    install_requires=['jina>=2.6.2', 'matplotlib'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     long_description_content_type='text/markdown',
     zip_safe=False,
     setup_requires=['setuptools>=18.0', 'wheel'],
-    install_requires=['jina>=2.6.2', 'matplotlib'],
+    install_requires=['jina>=2.4.9', 'matplotlib'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
The jina.math module has been moved to `docarray`. 
This PR changes the imports accordingly, to fix the failing tests. 