### PR TITLE
fix: handle exceptions in callbacks

### DIFF
--- a/finetuner/tuner/base.py
+++ b/finetuner/tuner/base.py
@@ -143,17 +143,16 @@ class BaseTuner(abc.ABC, Generic[AnyDNN, AnyDataLoader, AnyOptimizer, AnySchedul
     def _default_configure_optimizer(self, model: AnyDNN) -> AnyOptimizer:
         """Get the default optimizer (Adam), if none was provided by user."""
 
-    def _trigger_callbacks(self, method: str):
+    def _trigger_callbacks(self, method: str, **kwargs):
         """Trigger the specified method on all callbacks"""
         for callback in self._callbacks:
-            getattr(callback, method)(self)
+            getattr(callback, method)(self, **kwargs)
 
     @property
     def embed_model(self) -> AnyDNN:
         """Get the base model of this object."""
         return self._embed_model
 
-    @abc.abstractmethod
     def fit(
         self,
         train_data: 'DocumentSequence',
@@ -186,6 +185,20 @@ class BaseTuner(abc.ABC, Generic[AnyDNN, AnyDataLoader, AnyOptimizer, AnySchedul
             a Keras model.
         """
 
+        try:
+            self._fit(
+                train_data,
+                eval_data,
+                epochs,
+                batch_size,
+                num_items_per_class,
+                preprocess_fn,
+                collate_fn,
+                num_workers,
+            )
+        except BaseException as e:
+            self._trigger_callbacks('on_exception', exception=e)
+
     @abc.abstractmethod
     def save(self, *args, **kwargs):
         """Save the weights of the :py:attr:`.embed_model`."""
@@ -208,6 +221,21 @@ class BaseTuner(abc.ABC, Generic[AnyDNN, AnyDataLoader, AnyOptimizer, AnySchedul
         num_workers: int = 0,
     ) -> AnyDataLoader:
         """Get framework specific data loader from the input data."""
+        ...
+
+    @abc.abstractmethod
+    def _fit(
+        self,
+        train_data: 'DocumentSequence',
+        eval_data: Optional['DocumentSequence'] = None,
+        epochs: int = 10,
+        batch_size: int = 256,
+        num_items_per_class: Optional[int] = None,
+        preprocess_fn: Optional['PreprocFnType'] = None,
+        collate_fn: Optional['CollateFnType'] = None,
+        num_workers: int = 0,
+    ):
+        """Fit the model (training and evaluation)"""
         ...
 
     @abc.abstractmethod

--- a/finetuner/tuner/base.py
+++ b/finetuner/tuner/base.py
@@ -196,8 +196,11 @@ class BaseTuner(abc.ABC, Generic[AnyDNN, AnyDataLoader, AnyOptimizer, AnySchedul
                 collate_fn,
                 num_workers,
             )
+        except KeyboardInterrupt:
+            self._trigger_callbacks('on_keyboard_interrupt')
         except BaseException as e:
             self._trigger_callbacks('on_exception', exception=e)
+            raise
 
     @abc.abstractmethod
     def save(self, *args, **kwargs):

--- a/finetuner/tuner/callback/base.py
+++ b/finetuner/tuner/callback/base.py
@@ -83,3 +83,8 @@ class BaseCallback(ABC):
         """
         Called at the end of the ``fit`` method call, after finishing all the epochs.
         """
+
+    def on_exception(self, tuner: 'BaseTuner', exception: BaseException):
+        """
+        Called when the tuner encounters an exception during execution.
+        """

--- a/finetuner/tuner/callback/base.py
+++ b/finetuner/tuner/callback/base.py
@@ -84,6 +84,11 @@ class BaseCallback(ABC):
         Called at the end of the ``fit`` method call, after finishing all the epochs.
         """
 
+    def on_keyboard_interrupt(self, tuner: 'BaseTuner'):
+        """
+        Called when the tuner is interrupted by the user
+        """
+
     def on_exception(self, tuner: 'BaseTuner', exception: BaseException):
         """
         Called when the tuner encounters an exception during execution.

--- a/finetuner/tuner/callback/progress_bar.py
+++ b/finetuner/tuner/callback/progress_bar.py
@@ -136,6 +136,12 @@ class ProgressBarCallback(BaseCallback):
         """
         self._teardown()
 
+    def on_keyboard_interrupt(self, tuner: 'BaseTuner'):
+        """
+        Called when the tuner is interrupted by the user
+        """
+        self._teardown()
+
     def _teardown(self):
         """Stop the progress bar"""
         self.pbar.stop()

--- a/finetuner/tuner/callback/progress_bar.py
+++ b/finetuner/tuner/callback/progress_bar.py
@@ -125,4 +125,17 @@ class ProgressBarCallback(BaseCallback):
         self.pbar.update(task_id=self.eval_pbar_id, visible=False)
 
     def on_fit_end(self, tuner: 'BaseTuner'):
+        """
+        Called at the end of the ``fit`` method call, after finishing all the epochs.
+        """
+        self._teardown()
+
+    def on_exception(self, tuner: 'BaseTuner', exception: BaseException):
+        """
+        Called when the tuner encounters an exception during execution.
+        """
+        self._teardown()
+
+    def _teardown(self):
+        """Stop the progress bar"""
         self.pbar.stop()

--- a/finetuner/tuner/keras/__init__.py
+++ b/finetuner/tuner/keras/__init__.py
@@ -112,7 +112,7 @@ class KerasTuner(
 
         data.on_epoch_end()  # To re-create batches
 
-    def fit(
+    def _fit(
         self,
         train_data: 'DocumentSequence',
         eval_data: Optional['DocumentSequence'] = None,
@@ -121,23 +121,8 @@ class KerasTuner(
         num_items_per_class: Optional[int] = None,
         preprocess_fn: Optional['PreprocFnType'] = None,
         collate_fn: Optional['CollateFnType'] = None,
-        **kwargs,
+        num_workers: int = 0,
     ):
-        """Finetune the model on the training data.
-        :param train_data: Data on which to train the model
-        :param eval_data: Data on which to evaluate the model at the end of each epoch
-        :param preprocess_fn: A pre-processing function. It should take as input the
-            content of an item in the dataset and return the pre-processed content
-        :param collate_fn: The collation function to merge the content of individual
-            items into a batch. Should accept a list with the content of each item,
-            and output a tensor (or a list/dict of tensors) that feed directly into the
-            embedding model
-        :param epochs: Number of epochs to train the model
-        :param batch_size: The batch size to use for training and evaluation
-        :param num_items_per_class: Number of items from a single class to include in
-            the batch. Only relevant for class datasets
-        """
-
         # Get dataloaders
         train_dl = self._get_data_loader(
             train_data,

--- a/finetuner/tuner/paddle/__init__.py
+++ b/finetuner/tuner/paddle/__init__.py
@@ -137,7 +137,7 @@ class PaddleTuner(BaseTuner[nn.Layer, DataLoader, Optimizer, LRScheduler]):
 
             self._trigger_callbacks('on_train_batch_end')
 
-    def fit(
+    def _fit(
         self,
         train_data: 'DocumentSequence',
         eval_data: Optional['DocumentSequence'] = None,
@@ -147,23 +147,7 @@ class PaddleTuner(BaseTuner[nn.Layer, DataLoader, Optimizer, LRScheduler]):
         preprocess_fn: Optional['PreprocFnType'] = None,
         collate_fn: Optional['CollateFnType'] = None,
         num_workers: int = 0,
-        **kwargs,
     ):
-        """Finetune the model on the training data.
-        :param train_data: Data on which to train the model
-        :param eval_data: Data on which to evaluate the model at the end of each epoch
-        :param preprocess_fn: A pre-processing function. It should take as input the
-            content of an item in the dataset and return the pre-processed content
-        :param collate_fn: The collation function to merge the content of individual
-            items into a batch. Should accept a list with the content of each item,
-            and output a tensor (or a list/dict of tensors) that feed directly into the
-            embedding model
-        :param epochs: Number of epochs to train the model
-        :param batch_size: The batch size to use for training and evaluation
-        :param num_items_per_class: Number of items from a single class to include in
-            the batch. Only relevant for class datasets
-        :param num_workers: Number of workers used for loading the data.
-        """
         # Get dataloaders
         train_dl = self._get_data_loader(
             train_data,

--- a/finetuner/tuner/pytorch/__init__.py
+++ b/finetuner/tuner/pytorch/__init__.py
@@ -121,7 +121,6 @@ class PytorchTuner(BaseTuner[nn.Module, DataLoader, Optimizer, _LRScheduler]):
                 self.state.learning_rates[f'group_{param_idx}'] = param_group['lr']
 
             self._trigger_callbacks('on_train_batch_begin')
-
             inputs = _to_device(inputs, self.device)
             labels = _to_device(labels, self.device)
 
@@ -136,7 +135,6 @@ class PytorchTuner(BaseTuner[nn.Module, DataLoader, Optimizer, _LRScheduler]):
                 self._scheduler.step()
 
             self.state.current_loss = loss.item()
-
             self._trigger_callbacks('on_train_batch_end')
 
     def _fit(

--- a/finetuner/tuner/pytorch/__init__.py
+++ b/finetuner/tuner/pytorch/__init__.py
@@ -139,34 +139,17 @@ class PytorchTuner(BaseTuner[nn.Module, DataLoader, Optimizer, _LRScheduler]):
 
             self._trigger_callbacks('on_train_batch_end')
 
-    def fit(
+    def _fit(
         self,
         train_data: 'DocumentSequence',
         eval_data: Optional['DocumentSequence'] = None,
         epochs: int = 10,
         batch_size: int = 256,
         num_items_per_class: Optional[int] = None,
-        device: str = 'cpu',
         preprocess_fn: Optional['PreprocFnType'] = None,
         collate_fn: Optional['CollateFnType'] = None,
         num_workers: int = 0,
-        **kwargs,
     ):
-        """Finetune the model on the training data.
-        :param train_data: Data on which to train the model
-        :param eval_data: Data on which to evaluate the model at the end of each epoch
-        :param preprocess_fn: A pre-processing function. It should take as input the
-            content of an item in the dataset and return the pre-processed content
-        :param collate_fn: The collation function to merge the content of individual
-            items into a batch. Should accept a list with the content of each item,
-            and output a tensor (or a list/dict of tensors) that feed directly into the
-            embedding model
-        :param epochs: Number of epochs to train the model
-        :param batch_size: The batch size to use for training and evaluation
-        :param num_items_per_class: Number of items from a single class to include in
-            the batch. Only relevant for class datasets
-        :param num_workers: Number of workers used for loading the data.
-        """
         # Get dataloaders
         train_dl = self._get_data_loader(
             train_data,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -220,6 +220,25 @@ def expected_results():
 
 
 @pytest.fixture
+def exception_callback():
+    class ExceptionCallback(BaseCallback):
+        def __init__(self, exception):
+            self.exception = exception
+            self.calls = []
+
+        def on_fit_begin(self, tuner):
+            raise self.exception
+
+        def on_exception(self, tuner, exception):
+            self.calls.append('on_exception')
+
+        def on_keyboard_interrupt(self, tuner):
+            self.calls.append('on_keyboard_interrupt')
+
+    return ExceptionCallback
+
+
+@pytest.fixture
 def results_lr():
     """
     Get recorded learning rates for the exponential scheduler test

--- a/tests/integration/keras/test_callback.py
+++ b/tests/integration/keras/test_callback.py
@@ -1,3 +1,4 @@
+import pytest
 import tensorflow as tf
 from finetuner.tuner.keras import KerasTuner
 
@@ -35,3 +36,40 @@ def test_basic_callback(generate_random_data, expected_results, record_callback)
     assert record_callback.batch_idx == expected_batch_idx
     assert record_callback.num_batches_train == expected_num_batches_train
     assert record_callback.num_batches_val == expected_num_batches_val
+
+
+def test_on_exception(exception_callback, generate_random_data):
+    train_data = generate_random_data(8, 2, 2)
+    model = tf.keras.Sequential(
+        [
+            tf.keras.layers.Flatten(),
+            tf.keras.layers.Dense(10, activation='relu'),
+        ]
+    )
+    ec = exception_callback(ValueError('Test'))
+
+    # Train
+    tuner = KerasTuner(model, callbacks=[ec])
+
+    with pytest.raises(ValueError, match='Test'):
+        tuner.fit(train_data=train_data, epochs=1, batch_size=4, num_items_per_class=2)
+
+    assert ec.calls == ['on_exception']
+
+
+def test_on_keyboard_interrupt(exception_callback, generate_random_data):
+    train_data = generate_random_data(8, 2, 2)
+    model = tf.keras.Sequential(
+        [
+            tf.keras.layers.Flatten(),
+            tf.keras.layers.Dense(10, activation='relu'),
+        ]
+    )
+    ec = exception_callback(KeyboardInterrupt)
+
+    # Train
+    tuner = KerasTuner(model, callbacks=[ec])
+
+    tuner.fit(train_data=train_data, epochs=1, batch_size=4, num_items_per_class=2)
+
+    assert ec.calls == ['on_keyboard_interrupt']

--- a/tests/integration/paddle/test_callback.py
+++ b/tests/integration/paddle/test_callback.py
@@ -1,3 +1,4 @@
+import pytest
 from paddle import nn
 from finetuner.tuner.paddle import PaddleTuner
 
@@ -30,3 +31,30 @@ def test_basic_callback(generate_random_data, expected_results, record_callback)
     assert record_callback.batch_idx == expected_batch_idx
     assert record_callback.num_batches_train == expected_num_batches_train
     assert record_callback.num_batches_val == expected_num_batches_val
+
+
+def test_on_exception(exception_callback, generate_random_data):
+    train_data = generate_random_data(8, 2, 2)
+    model = nn.Sequential(nn.Flatten(), nn.Linear(in_features=2, out_features=2))
+    ec = exception_callback(ValueError('Test'))
+
+    # Train
+    tuner = PaddleTuner(model, callbacks=[ec])
+
+    with pytest.raises(ValueError, match='Test'):
+        tuner.fit(train_data=train_data, epochs=1, batch_size=4, num_items_per_class=2)
+
+    assert ec.calls == ['on_exception']
+
+
+def test_on_keyboard_interrupt(exception_callback, generate_random_data):
+    train_data = generate_random_data(8, 2, 2)
+    model = nn.Sequential(nn.Flatten(), nn.Linear(in_features=2, out_features=2))
+    ec = exception_callback(KeyboardInterrupt)
+
+    # Train
+    tuner = PaddleTuner(model, callbacks=[ec])
+
+    tuner.fit(train_data=train_data, epochs=1, batch_size=4, num_items_per_class=2)
+
+    assert ec.calls == ['on_keyboard_interrupt']


### PR DESCRIPTION
This adds a new `on_exception` hook to the callbacks. It is used in progress bar to properly shut it down if an exception occurs.