### PR TITLE
refactor(tailor): add bottleneck without sequence model

### DIFF
--- a/finetuner/tailor/paddle/__init__.py
+++ b/finetuner/tailor/paddle/__init__.py
@@ -193,10 +193,7 @@ class PaddleTailor(BaseTailor):
                 _relative_idx_to_embedding_layer += 1
 
         if bottleneck_net:
-            model = nn.Sequential(
-                model,
-                bottleneck_net,
-            )
+            model.add_sublayer('bottleneck_net', bottleneck_net)
 
         return model
 

--- a/finetuner/tailor/pytorch/__init__.py
+++ b/finetuner/tailor/pytorch/__init__.py
@@ -189,8 +189,6 @@ class PytorchTailor(BaseTailor):
                 _relative_idx_to_embedding_layer += 1
 
         if bottleneck_net:
-            return nn.Sequential(
-                model,
-                bottleneck_net,
-            )
+            model.add_module('bottleneck_net', bottleneck_net)
+
         return model


### PR DESCRIPTION
a better option to add a bottleneck layer to the embed model, rather than use another `Sequence` wrapper.