### PR TITLE
fix: add normalization to preprocessor

### DIFF
--- a/finetuner/tailor/keras/projection_head.py
+++ b/finetuner/tailor/keras/projection_head.py
@@ -27,6 +27,7 @@ class ProjectionHead(tf.keras.layers.Layer):
                 bias_initializer='zeros',
             )
         )
+        self.layers.append(tf.keras.layers.BatchNormalization(epsilon=self.EPSILON))
 
     def call(self, x):
         for layer in self.layers:

--- a/finetuner/tailor/keras/projection_head.py
+++ b/finetuner/tailor/keras/projection_head.py
@@ -9,7 +9,7 @@ class ProjectionHead(tf.keras.layers.Layer):
 
     EPSILON = 1e-5
 
-    def __init__(self, in_features: int, output_dim: int = 128, num_layers: int = 3):
+    def __init__(self, in_features: int, output_dim: int = 128, num_layers: int = 2):
         super().__init__()
         self.layers = []
         for idx in range(num_layers - 1):

--- a/finetuner/tailor/paddle/projection_head.py
+++ b/finetuner/tailor/paddle/projection_head.py
@@ -9,7 +9,7 @@ class ProjectionHead(nn.Layer):
 
     EPSILON = 1e-5
 
-    def __init__(self, in_features: int, output_dim: int = 128, num_layers: int = 3):
+    def __init__(self, in_features: int, output_dim: int = 128, num_layers: int = 2):
         super().__init__()
         self.head_layers = nn.LayerList()
         for idx in range(num_layers - 1):

--- a/finetuner/tailor/paddle/projection_head.py
+++ b/finetuner/tailor/paddle/projection_head.py
@@ -31,6 +31,9 @@ class ProjectionHead(nn.Layer):
                 bias_attr=False,
             )
         )
+        self.head_layers.append(
+            nn.BatchNorm1D(num_features=output_dim, epsilon=self.EPSILON)
+        )
 
     def forward(self, x):
         for layer in self.head_layers:

--- a/finetuner/tailor/pytorch/projection_head.py
+++ b/finetuner/tailor/pytorch/projection_head.py
@@ -9,7 +9,7 @@ class ProjectionHead(nn.Module):
 
     EPSILON = 1e-5
 
-    def __init__(self, in_features: int, output_dim: int = 128, num_layers: int = 3):
+    def __init__(self, in_features: int, output_dim: int = 128, num_layers: int = 2):
         super().__init__()
         self.head_layers = nn.ModuleList()
         for idx in range(num_layers - 1):
@@ -22,6 +22,9 @@ class ProjectionHead(nn.Module):
             self.head_layers.append(nn.ReLU())
         self.head_layers.append(
             nn.Linear(in_features=in_features, out_features=output_dim, bias=False)
+        )
+        self.head_layers.append(
+            nn.BatchNorm1d(num_features=output_dim, eps=self.EPSILON)
         )
 
     def forward(self, x):

--- a/finetuner/tuner/augmentation.py
+++ b/finetuner/tuner/augmentation.py
@@ -7,7 +7,7 @@ def vision_preprocessor(
     width: int = 224,
     default_channel_axis: int = -1,
     target_channel_axis: int = 0,
-    phrase: str = 'train',
+    phase: str = 'train',
 ):
     """Randomly augmentation a Document with `blob` field.
     The method applies flipping, color jitter, cropping, gaussian blur and random rectangle erase
@@ -17,13 +17,13 @@ def vision_preprocessor(
     :param width: image width.
     :param default_channel_axis: The color channel of the input image, by default -1, the expected input is H, W, C.
     :param target_channel_axis: The color channel of the output image, by default 0, the expected output is C, H, W.
-    :param phrase: phrase of experiment, either `train` or `validation`. At `validation` phrase, will not apply
+    :param phase: phase of experiment, either `train` or `validation`. At `validation` phase, will not apply
       random transformation.
     """
 
     def preprocess_fn(doc):
         return _vision_preprocessor(
-            doc, height, width, default_channel_axis, target_channel_axis, phrase
+            doc, height, width, default_channel_axis, target_channel_axis, phase
         )
 
     return preprocess_fn
@@ -51,7 +51,7 @@ def _set_image_blob_normalization(
     .. warning::
         Please do NOT generalize this function to gray scale, black/white image, it does not make any sense for
         non RGB image. if you look at their MNIST examples, the mean and stddev are 1-dimensional
-        (since the inputs are greyscale-- no RGB channels).
+        (since the inputs are greyscale there is no RGB channels).
 
 
     """
@@ -71,7 +71,7 @@ def _vision_preprocessor(
     width: int = 224,
     default_channel_axis: int = -1,
     target_channel_axis: int = 0,
-    phrase: str = 'train',
+    phase: str = 'train',
 ):
     """Randomly augmentation a Document with `blob` field.
     The method applies flipping, color jitter, cropping, gaussian blur and random rectangle erase
@@ -82,7 +82,7 @@ def _vision_preprocessor(
     :param width: image width.
     :param default_channel_axis: The color channel of the input image, by default -1, the expected input is H, W, C.
     :param target_channel_axis: The color channel of the output image, by default 0, the expected output is C, H, W.
-    :param phrase: phrase of experiment, either `train` or `validation`. At `validation` phrase, will not apply
+    :param phase: stage of experiment, either `train` or `validation`. At `validation` phase, will not apply
         random transformation.
     """
     import albumentations as A
@@ -105,7 +105,7 @@ def _vision_preprocessor(
         blob = np.float32(blob)
     if default_channel_axis not in [-1, 2]:
         blob = np.moveaxis(blob, default_channel_axis, -1)
-    if phrase == 'train':
+    if phase == 'train':
         transform = A.Compose(
             [
                 A.HorizontalFlip(p=0.5),

--- a/finetuner/tuner/augmentation.py
+++ b/finetuner/tuner/augmentation.py
@@ -7,6 +7,7 @@ def vision_preprocessor(
     width: int = 224,
     default_channel_axis: int = -1,
     target_channel_axis: int = 0,
+    phrase: str = 'train',
 ):
     """Randomly augmentation a Document with `blob` field.
     The method applies flipping, color jitter, cropping, gaussian blur and random rectangle erase
@@ -16,14 +17,52 @@ def vision_preprocessor(
     :param width: image width.
     :param default_channel_axis: The color channel of the input image, by default -1, the expected input is H, W, C.
     :param target_channel_axis: The color channel of the output image, by default 0, the expected output is C, H, W.
+    :param phrase: phrase of experiment, either `train` or `validation`. At `validation` phrase, will not apply
+      random transformation.
     """
 
     def preprocess_fn(doc):
         return _vision_preprocessor(
-            doc, height, width, default_channel_axis, target_channel_axis
+            doc, height, width, default_channel_axis, target_channel_axis, phrase
         )
 
     return preprocess_fn
+
+
+def _set_image_blob_normalization(
+    blob,
+    channel_axis: int = -1,
+    img_mean=(0.485, 0.456, 0.406),
+    img_std=(0.229, 0.224, 0.225),
+) -> np.ndarray:
+    """Normalize a uint8 image :attr:`.blob` into a float32 image :attr:`.blob` inplace.
+
+    Following Pytorch standard, the image must be in the shape of shape (3 x H x W) and
+    will be normalized in to a range of [0, 1] and then
+    normalized using mean = [0.485, 0.456, 0.406] and std = [0.229, 0.224, 0.225]. These two arrays are computed
+    based on millions of images. If you want to train from scratch on your own dataset, you can calculate the new
+    mean and std. Otherwise, using the Imagenet pretrianed model with its own mean and std is recommended.
+
+    :param channel_axis: the axis id of the color channel, ``-1`` indicates the color channel info at the last axis
+    :param img_mean: the mean of all images
+    :param img_std: the standard deviation of all images
+    :return: itself after processed
+
+    .. warning::
+        Please do NOT generalize this function to gray scale, black/white image, it does not make any sense for
+        non RGB image. if you look at their MNIST examples, the mean and stddev are 1-dimensional
+        (since the inputs are greyscale-- no RGB channels).
+
+
+    """
+    blob = (blob / 255.0).astype(np.float32)
+    blob = np.moveaxis(blob, channel_axis, 0)
+    mean = np.asarray(img_mean, dtype=np.float32)
+    std = np.asarray(img_std, dtype=np.float32)
+    blob = (blob - mean[:, None, None]) / std[:, None, None]
+    # set back channel to original
+    blob = np.moveaxis(blob, 0, channel_axis)
+    return blob
 
 
 def _vision_preprocessor(
@@ -32,6 +71,7 @@ def _vision_preprocessor(
     width: int = 224,
     default_channel_axis: int = -1,
     target_channel_axis: int = 0,
+    phrase: str = 'train',
 ):
     """Randomly augmentation a Document with `blob` field.
     The method applies flipping, color jitter, cropping, gaussian blur and random rectangle erase
@@ -42,6 +82,8 @@ def _vision_preprocessor(
     :param width: image width.
     :param default_channel_axis: The color channel of the input image, by default -1, the expected input is H, W, C.
     :param target_channel_axis: The color channel of the output image, by default 0, the expected output is C, H, W.
+    :param phrase: phrase of experiment, either `train` or `validation`. At `validation` phrase, will not apply
+        random transformation.
     """
     import albumentations as A
 
@@ -55,22 +97,25 @@ def _vision_preprocessor(
             blob = doc.blob
         else:
             raise AttributeError('Can not load `blob` field from the given document.')
+    if blob.dtype == np.uint8:
+        blob = _set_image_blob_normalization(blob, channel_axis=default_channel_axis)
+    if blob.dtype == np.float64:
+        blob = np.float32(blob)
     if default_channel_axis not in [-1, 2]:
         blob = np.moveaxis(blob, default_channel_axis, -1)
-    if blob.dtype == np.uint8:
-        blob = (blob / 255.0).astype(np.float32)
-    transform = A.Compose(
-        [
-            A.HorizontalFlip(p=0.5),
-            A.ColorJitter(p=1),
-            A.RandomResizedCrop(width=width, height=height, p=1),
-            A.GaussianBlur(p=1),
-            A.GridDropout(
-                ratio=0.2, p=0.5
-            ),  # random erase 0.2 percent of image with 0.5 probability
-        ]
-    )
-    blob = transform(image=blob)['image']
+    if phrase == 'train':
+        transform = A.Compose(
+            [
+                A.HorizontalFlip(p=0.5),
+                A.ColorJitter(p=1),
+                A.RandomResizedCrop(width=width, height=height, p=1),
+                A.GaussianBlur(p=1),
+                A.GridDropout(
+                    ratio=0.2, p=0.5
+                ),  # random erase 0.2 percent of image with 0.5 probability
+            ]
+        )
+        blob = transform(image=blob)['image']
     if target_channel_axis != -1:
         blob = np.moveaxis(blob, -1, target_channel_axis)
     return blob

--- a/finetuner/tuner/augmentation.py
+++ b/finetuner/tuner/augmentation.py
@@ -59,7 +59,7 @@ def _vision_preprocessor(
         blob = np.moveaxis(blob, default_channel_axis, -1)
     if blob.dtype == 'uint8':  # normalize image blob
         blob_info = np.iinfo(blob.dtype)
-        blob = (blob.astype(np.float64) / blob_info.max) * 255
+        blob = (blob.astype(np.float32) / blob_info.max) * 255
     transform = A.Compose(
         [
             A.HorizontalFlip(p=0.5),

--- a/finetuner/tuner/augmentation.py
+++ b/finetuner/tuner/augmentation.py
@@ -29,42 +29,6 @@ def vision_preprocessor(
     return preprocess_fn
 
 
-def _set_image_blob_normalization(
-    blob,
-    channel_axis: int = -1,
-    img_mean=(0.485, 0.456, 0.406),
-    img_std=(0.229, 0.224, 0.225),
-) -> np.ndarray:
-    """Normalize a uint8 image :attr:`.blob` into a float32 image :attr:`.blob` inplace.
-
-    Following Pytorch standard, the image must be in the shape of shape (3 x H x W) and
-    will be normalized in to a range of [0, 1] and then
-    normalized using mean = [0.485, 0.456, 0.406] and std = [0.229, 0.224, 0.225]. These two arrays are computed
-    based on millions of images. If you want to train from scratch on your own dataset, you can calculate the new
-    mean and std. Otherwise, using the Imagenet pretrianed model with its own mean and std is recommended.
-
-    :param channel_axis: the axis id of the color channel, ``-1`` indicates the color channel info at the last axis
-    :param img_mean: the mean of all images
-    :param img_std: the standard deviation of all images
-    :return: itself after processed
-
-    .. warning::
-        Please do NOT generalize this function to gray scale, black/white image, it does not make any sense for
-        non RGB image. if you look at their MNIST examples, the mean and stddev are 1-dimensional
-        (since the inputs are greyscale there is no RGB channels).
-
-
-    """
-    blob = (blob / 255.0).astype(np.float32)
-    blob = np.moveaxis(blob, channel_axis, 0)
-    mean = np.asarray(img_mean, dtype=np.float32)
-    std = np.asarray(img_std, dtype=np.float32)
-    blob = (blob - mean[:, None, None]) / std[:, None, None]
-    # set back channel to original
-    blob = np.moveaxis(blob, 0, channel_axis)
-    return blob
-
-
 def _vision_preprocessor(
     doc: Document,
     height: int = 224,
@@ -99,12 +63,18 @@ def _vision_preprocessor(
             raise AttributeError(
                 f'Document `blob` is None, loading it from url: {doc.uri} failed.'
             )
-    if blob.dtype == np.uint8:
-        blob = _set_image_blob_normalization(blob, channel_axis=default_channel_axis)
     if blob.dtype == np.float64:
         blob = np.float32(blob)
     if default_channel_axis not in [-1, 2]:
         blob = np.moveaxis(blob, default_channel_axis, -1)
+    if blob.shape[-1] == 3:  # apply to RGB images.
+        transform = A.Compose(
+            [
+                A.Normalize(),
+                A.ToFloat(),
+            ]
+        )
+        blob = transform(image=blob)['image']
     if phase == 'train':
         transform = A.Compose(
             [

--- a/finetuner/tuner/augmentation.py
+++ b/finetuner/tuner/augmentation.py
@@ -57,9 +57,8 @@ def _vision_preprocessor(
             raise AttributeError('Can not load `blob` field from the given document.')
     if default_channel_axis not in [-1, 2]:
         blob = np.moveaxis(blob, default_channel_axis, -1)
-    if blob.dtype == 'uint8':  # normalize image blob
-        blob_info = np.iinfo(blob.dtype)
-        blob = (blob.astype(np.float32) / blob_info.max) * 255
+    if blob.dtype == np.uint8 and blob.ndim == 3:
+        blob = (blob / 255.0).astype(np.float32)
     transform = A.Compose(
         [
             A.HorizontalFlip(p=0.5),

--- a/finetuner/tuner/augmentation.py
+++ b/finetuner/tuner/augmentation.py
@@ -96,7 +96,9 @@ def _vision_preprocessor(
             )
             blob = doc.blob
         else:
-            raise AttributeError('Can not load `blob` field from the given document.')
+            raise AttributeError(
+                f'Document `blob` is None, loading it from url: {doc.uri} failed.'
+            )
     if blob.dtype == np.uint8:
         blob = _set_image_blob_normalization(blob, channel_axis=default_channel_axis)
     if blob.dtype == np.float64:

--- a/finetuner/tuner/augmentation.py
+++ b/finetuner/tuner/augmentation.py
@@ -55,6 +55,8 @@ def _vision_preprocessor(
             blob = doc.blob
         else:
             raise AttributeError('Can not load `blob` field from the given document.')
+    if blob.dtype == 'uint8':
+        doc.set_image_blob_normalization(channel_axis=default_channel_axis)
     if default_channel_axis not in [-1, 2]:
         blob = np.moveaxis(blob, default_channel_axis, -1)
     # p is the probability to apply the transform.

--- a/finetuner/tuner/augmentation.py
+++ b/finetuner/tuner/augmentation.py
@@ -57,12 +57,12 @@ def _vision_preprocessor(
             raise AttributeError('Can not load `blob` field from the given document.')
     if default_channel_axis not in [-1, 2]:
         blob = np.moveaxis(blob, default_channel_axis, -1)
-    if blob.dtype == np.uint8 and blob.ndim == 3:
+    if blob.dtype == np.uint8:
         blob = (blob / 255.0).astype(np.float32)
     transform = A.Compose(
         [
             A.HorizontalFlip(p=0.5),
-            A.ColorJitter(p=1, brightness=0, contrast=0, saturation=0, hue=0),
+            A.ColorJitter(p=1),
             A.RandomResizedCrop(width=width, height=height, p=1),
             A.GaussianBlur(p=1),
             A.GridDropout(

--- a/tests/unit/tuner/test_augmentation.py
+++ b/tests/unit/tuner/test_augmentation.py
@@ -9,13 +9,14 @@ from finetuner.tuner.augmentation import _vision_preprocessor
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 
+@pytest.mark.parametrize('phrase', ['train', 'validation'])
 @pytest.mark.parametrize(
     'doc, height, width, num_channels, default_channel_axis, target_channel_axis',
     [
         (Document(blob=np.random.rand(224, 224, 3)), 224, 224, 3, -1, 0),
         (Document(blob=np.random.rand(256, 256, 3)), 256, 256, 3, -1, 0),
         (
-            Document(blob=np.random.rand(224, 224, 3).astype('uint8')),
+            Document(blob=np.random.rand(256, 256, 3).astype('uint8')),
             256,
             256,
             3,
@@ -50,11 +51,11 @@ cur_dir = os.path.dirname(os.path.abspath(__file__))
     ],
 )
 def test_vision_preprocessor(
-    doc, height, width, num_channels, default_channel_axis, target_channel_axis
+    doc, height, width, num_channels, default_channel_axis, target_channel_axis, phrase
 ):
     original_blob = doc.blob
     augmented_blob = _vision_preprocessor(
-        doc, height, width, default_channel_axis, target_channel_axis
+        doc, height, width, default_channel_axis, target_channel_axis, phrase
     )
     assert augmented_blob is not None
     assert not np.array_equal(original_blob, augmented_blob)
@@ -65,7 +66,7 @@ def test_vision_preprocessor(
         assert augmented_blob.shape == (num_channels, height, width)
 
 
-def test_vision_preprocessor_fail_given_no_blob_and_uri():
-    doc = Document()
-    with pytest.raises(AttributeError):
-        _vision_preprocessor(doc)
+# def test_vision_preprocessor_fail_given_no_blob_and_uri():
+#     doc = Document()
+#     with pytest.raises(AttributeError):
+#         _vision_preprocessor(doc)

--- a/tests/unit/tuner/test_augmentation.py
+++ b/tests/unit/tuner/test_augmentation.py
@@ -14,6 +14,14 @@ cur_dir = os.path.dirname(os.path.abspath(__file__))
     [
         (Document(blob=np.random.rand(224, 224, 3)), 224, 224, 3, -1, 0),
         (Document(blob=np.random.rand(256, 256, 3)), 256, 256, 3, -1, 0),
+        (
+            Document(blob=np.random.rand(224, 224, 3).astype('uint8')),
+            256,
+            256,
+            3,
+            -1,
+            0,
+        ),
         (Document(blob=np.random.rand(256, 256, 1)), 256, 256, 1, -1, 0),  # grayscale
         (
             Document(blob=np.random.rand(256, 256, 3)),
@@ -49,11 +57,12 @@ def test_vision_preprocessor(
         doc, height, width, default_channel_axis, target_channel_axis
     )
     assert augmented_blob is not None
+    assert not np.array_equal(original_blob, augmented_blob)
+    assert np.issubdtype(augmented_blob.dtype, np.floating)
     if target_channel_axis == -1:
         assert augmented_blob.shape == (height, width, num_channels)
     elif target_channel_axis == 0:
         assert augmented_blob.shape == (num_channels, height, width)
-    assert not np.array_equal(original_blob, augmented_blob)
 
 
 def test_vision_preprocessor_fail_given_no_blob_and_uri():

--- a/tests/unit/tuner/test_augmentation.py
+++ b/tests/unit/tuner/test_augmentation.py
@@ -66,7 +66,7 @@ def test_vision_preprocessor(
         assert augmented_blob.shape == (num_channels, height, width)
 
 
-# def test_vision_preprocessor_fail_given_no_blob_and_uri():
-#     doc = Document()
-#     with pytest.raises(AttributeError):
-#         _vision_preprocessor(doc)
+def test_vision_preprocessor_fail_given_no_blob_and_uri():
+    doc = Document()
+    with pytest.raises(AttributeError):
+        _vision_preprocessor(doc)

--- a/tests/unit/tuner/test_augmentation.py
+++ b/tests/unit/tuner/test_augmentation.py
@@ -9,7 +9,7 @@ from finetuner.tuner.augmentation import _vision_preprocessor
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 
-@pytest.mark.parametrize('phrase', ['train', 'validation'])
+@pytest.mark.parametrize('phase', ['train', 'validation'])
 @pytest.mark.parametrize(
     'doc, height, width, num_channels, default_channel_axis, target_channel_axis',
     [
@@ -51,11 +51,11 @@ cur_dir = os.path.dirname(os.path.abspath(__file__))
     ],
 )
 def test_vision_preprocessor(
-    doc, height, width, num_channels, default_channel_axis, target_channel_axis, phrase
+    doc, height, width, num_channels, default_channel_axis, target_channel_axis, phase
 ):
     original_blob = doc.blob
     augmented_blob = _vision_preprocessor(
-        doc, height, width, default_channel_axis, target_channel_axis, phrase
+        doc, height, width, default_channel_axis, target_channel_axis, phase
     )
     assert augmented_blob is not None
     assert not np.array_equal(original_blob, augmented_blob)


### PR DESCRIPTION
a set of minor updates based on experiments:

1. change `num_layers` of `projection_head` to 2. based on simclrv2 paper.
2. added another `batchnorm1d` at the end of default `projection_head`.
3. add `phrase` option in `vision_preprocessor`, to apply augmentation at evaluation time.