### PR TITLE
feat: use `da.evaluate` in Evaluator + configurable metrics

### DIFF
--- a/docs/components/tuner/evaluation.md
+++ b/docs/components/tuner/evaluation.md
@@ -8,7 +8,7 @@ or integrated in the training loop via the [evaluation callback](#using-the-eval
 
 ## Using the evaluator
 
-The evaluator can be used standalone in order to compute the evaluation metrics on a sequence
+The evaluator can be used standalone in order to compute evaluation metrics on a sequence
 of documents:
 ```python
 from finetuner.tuner.evaluation import Evaluator
@@ -34,7 +34,7 @@ The `index_data` (or catalog) is an optional argument that defines the dataset a
 query docs are matched. If not provided, query docs are matched against themselves.
 
 The `evaluate()` method returns the computed metrics as a dictionary, mapping metric names to values.
-The computed metrics are the following:
+By default, the following metrics are computed:
 
 - Precision
 - Recall
@@ -46,7 +46,7 @@ The computed metrics are the following:
 - DCG
 - NDCG
 
-More information on Information Retrieval metrics can be found
+More details on these Information Retrieval metrics can be found
 [here](https://en.wikipedia.org/wiki/Evaluation_measures_(information_retrieval)).
 
 Let's consider an example. First, let's build a model that receives a NumPy array with a single element as input, and
@@ -63,7 +63,6 @@ class EmbeddingModel(torch.nn.Module):
         output_shape: (bs, 10)
         """
         return inputs.repeat(1, 10)
-
 ```
 
 Now let's create some example data. We will divide into 2 sets, the evaluation data and the index data. The
@@ -134,7 +133,7 @@ evaluator = Evaluator(query_data, index_data, embed_model)
 metrics = evaluator.evaluate(limit=1, distance='euclidean')
 print(metrics)
 ```
-```
+```json
 {
   "r_precision": 1.0,
   "precision_at_k": 1.0,
@@ -153,7 +152,7 @@ When evaluating with a bigger matching limit, we expect precision to drop:
 metrics = evaluator.evaluate(limit=2, distance='euclidean')
 print(metrics)
 ```
-```
+```json
 {
   "r_precision": 1.0,
   "precision_at_k": 0.5,
@@ -164,6 +163,35 @@ print(metrics)
   "reciprocal_rank": 1.0,
   "dcg_at_k": 1.0,
   "ndcg_at_k": 1.0
+}
+```
+
+To customize the computed metrics, an optional `metrics` argument can be provided in
+the Evaluator constructor, that maps metric names to metric functions and keyword
+arguments. For example:
+
+```python
+from docarray.math.evaluation import precision_at_k, recall_at_k
+
+def f_score_at_k(binary_relevance, max_rel, k=None, beta=1.0):
+    precision = precision_at_k(binary_relevance, k=k)
+    recall = recall_at_k(binary_relevance, max_rel, k=k)
+    return ((1+ beta**2) * precision * recall) / (beta**2 * precision + recall)
+
+metrics = {
+    'precision@5': (precision_at_k, {'k': 5}),
+    'recall@5': (recall_at_k, {'k': 5}),
+    'f1score@5': (f_score_at_k, {'k': 5, 'beta': 1.0})
+}
+
+evaluator = Evaluator(query_data, index_data, embed_model, metrics=metrics)
+print(evaluator.evaluate(limit=2, distance='euclidean'))
+```
+```json
+{
+  "precision@5": 0.2,
+  "recall@5": 1.0,
+  "f1score@5": 0.33333333333333337
 }
 ```
 

--- a/finetuner/tuner/callback/evaluation.py
+++ b/finetuner/tuner/callback/evaluation.py
@@ -40,7 +40,7 @@ class EvaluationCallback(BaseCallback):
             to None, default metrics are computed.
         :param exclude_self: Whether to exclude self when matching.
         :param limit: The number of top search results to consider, when computing the
-            valuation metrics.
+            evaluation metrics.
         :param distance: The type of distance metric to use when matching query and
             index docs, available options are ``'cosine'``, ``'euclidean'`` and
             ``'sqeuclidean'``.

--- a/finetuner/tuner/evaluation.py
+++ b/finetuner/tuner/evaluation.py
@@ -11,7 +11,9 @@ if TYPE_CHECKING:
 
 
 class Evaluator:
-    """The evaluator class"""
+    """
+    The evaluator class.
+    """
 
     def __init__(
         self,
@@ -24,13 +26,13 @@ class Evaluator:
         Build an Evaluator object that can be used to evaluate the performance on a
         retrieval task.
 
-        :param query_data: A sequence of documents. Both class and session format is
+        :param query_data: The evaluation data. Both class and session format is
             accepted. In the case of session data, each document should contain ground
             truth matches from the index data under ``doc.matches``. In the case of
             class format, each document should be mapped to a class, which is specified
             under ``doc.tags[finetuner.__default_tag_key__]``.
-        :param index_data: A sequence of documents, against which the query data will
-            be matched. If not provided, query data will be matched against themselves.
+        :param index_data: The data against which the query data will be matched.
+            If not provided, query data will be matched against themselves.
             Both class and session format is accepted. In the case of session data,
             ground truth matches are included in the `query_data`, so no additional
             information is required in the index data. In the case of class data, each
@@ -63,7 +65,7 @@ class Evaluator:
         """
         label = doc.tags.get(__default_tag_key__)
         if label is None:
-            raise ValueError(f'No label found in index doc with id: {doc.id}')
+            raise ValueError(f'No label found in doc with id: {doc.id}')
         return label
 
     def _parse_class_docs(self) -> DocumentArray:
@@ -172,7 +174,7 @@ class Evaluator:
         **embed_kwargs,
     ) -> Dict[str, float]:
         """
-        Run evaluation
+        Compute evaluation metrics.
         :param exclude_self: Whether to exclude self when matching.
         :param limit: The number of top search results to consider, when computing the
             evaluation metrics.

--- a/tests/unit/tuner/test_evaluation.py
+++ b/tests/unit/tuner/test_evaluation.py
@@ -4,12 +4,7 @@ import torch
 from docarray import Document, DocumentArray
 
 from finetuner import __default_tag_key__
-from finetuner.tuner.evaluation import (
-    METRICS,
-    Evaluator,
-    __evaluator_metrics_key__,
-    __evaluator_targets_key__,
-)
+from finetuner.tuner.evaluation import Evaluator
 
 DATASET_SIZE = 1000
 EMBEDDING_SIZE = 10
@@ -79,12 +74,13 @@ def test_parse_session_docs(query_session_data, index_session_data):
     Test the conversion from session docs to the internal evaluator representation
     """
     evaluator = Evaluator(query_session_data, index_session_data)
-    summarydocs = evaluator._parse_session_docs()
-    for evaldoc, summarydoc in zip(query_session_data, summarydocs):
-        assert evaldoc.id == summarydoc.id
-        assert summarydoc.content is None
-        assert evaldoc.matches[0].id in summarydoc.tags[__evaluator_targets_key__]
-        assert summarydoc.tags[__evaluator_targets_key__][evaldoc.matches[0].id] == 1
+    ground_truth = evaluator._parse_session_docs()
+    for query_doc, ground_truth_doc in zip(query_session_data, ground_truth):
+        assert query_doc.id == ground_truth_doc.id
+        assert ground_truth_doc.content is None
+        query_doc_matches = [m.id for m in query_doc.matches]
+        ground_truth_doc_matches = [m.id for m in ground_truth_doc.matches]
+        assert query_doc_matches == ground_truth_doc_matches
 
 
 def test_parse_class_docs(query_class_data, index_class_data):
@@ -92,21 +88,24 @@ def test_parse_class_docs(query_class_data, index_class_data):
     Test the conversion from class docs to the internal evaluator representation
     """
     evaluator = Evaluator(query_class_data, index_class_data)
-    summarydocs = evaluator._parse_class_docs()
-    for evaldoc, summarydoc in zip(query_class_data, summarydocs):
-        assert evaldoc.id == summarydoc.id
-        assert summarydoc.content is None
-        targets = list(summarydoc.tags[__evaluator_targets_key__].items())
-        assert len(targets) == 1
-        target, relevance = targets[0]
-        assert relevance == 1
+    ground_truth = evaluator._parse_class_docs()
+    for query_doc, ground_truth_doc in zip(query_class_data, ground_truth):
+        assert query_doc.id == ground_truth_doc.id
+        assert ground_truth_doc.content is None
+        ground_truth_doc_matches = [m.id for m in ground_truth_doc.matches]
+        assert len(ground_truth_doc_matches) == 1
 
 
-def test_list_available_metrics(embed_model):
+def test_default_metrics(embed_model):
     """
-    Test the listing of available metrics
+    Test the listing of default metrics
     """
-    assert Evaluator.list_available_metrics() == list(METRICS.keys())
+    metrics = Evaluator.default_metrics()
+    for key, (func, kwargs) in metrics.items():
+        assert isinstance(key, str)
+        assert callable(func)
+        assert isinstance(kwargs, dict)
+        _ = func([1, 0], max_rel=2)
 
 
 def test_evaluator_perfect_scores(
@@ -130,8 +129,8 @@ def test_evaluator_perfect_scores(
         for _, v in metrics.items():
             assert v == 1.0
         for doc in _query_data:
-            for _, v in doc.tags[__evaluator_metrics_key__].items():
-                assert v == 1.0
+            for _, v in doc.evaluations.items():
+                assert v.value == 1.0
 
 
 def test_evaluator_half_precision(
@@ -142,8 +141,8 @@ def test_evaluator_half_precision(
     index_class_data,
 ):
     """
-    Test the evaluator when the matching limit is set 2. We expect all metrics == 1.0 except
-    precision == 0.5 and f1score == 2/3
+    Test the evaluator when the matching limit is set 2. We expect all metrics == 1.0
+    except precision == 0.5 and f1score == 2/3
     """
     # test both for session and class data
     for _query_data, _index_data in [
@@ -160,13 +159,13 @@ def test_evaluator_half_precision(
             else:
                 assert v == 1.0
         for doc in _query_data:
-            for k, v in doc.tags[__evaluator_metrics_key__].items():
+            for k, v in doc.evaluations.items():
                 if k == 'precision_at_k':
-                    assert v == 0.5
+                    assert v.value == 0.5
                 elif k == 'f1_score_at_k':
-                    assert 0.66 < v < 0.67
+                    assert 0.66 < v.value < 0.67
                 else:
-                    assert v == 1.0
+                    assert v.value == 1.0
 
 
 def test_evaluator_no_index_data(embed_model, query_class_data):
@@ -175,3 +174,22 @@ def test_evaluator_no_index_data(embed_model, query_class_data):
     """
     evaluator = Evaluator(query_class_data, embed_model=embed_model)
     _ = evaluator.evaluate()
+
+
+def test_evaluator_custom_metric(embed_model, query_class_data):
+    """
+    Test using custom metrics
+    """
+
+    def my_metric(*_, **__):
+        return 0.5
+
+    evaluator = Evaluator(
+        query_class_data,
+        embed_model=embed_model,
+        metrics={'my_metric': (my_metric, {})},
+    )
+    metrics = evaluator.evaluate()
+    assert len(metrics) == 1
+    assert 'my_metric' in metrics
+    assert metrics['my_metric'] == 0.5


### PR DESCRIPTION
closes #321 #299

Use `docarray`s `.evaluate` method in the Evaluator. Enable configuration of metrics, via argument `metrics`.

```
evaluator = Evaluator(
    ...
    metrics={
        'precision@5': (precision_at_k, {'k': 5})
    }
)
```