### PR TITLE
Refactor device module 368

### DIFF
--- a/finetuner/device.py
+++ b/finetuner/device.py
@@ -1,0 +1,87 @@
+from typing import Dict, List, Mapping, Sequence, Union
+from .helper import AnyTensor
+
+def get_device_pytorch(device: str):
+    """Get Pytorch compute device.
+    :param device: device name.
+    """
+    
+    import torch
+    
+    # translate our own alias into framework-compatible ones
+    return torch.device(device)
+
+
+def to_device_pytorch(
+    inputs: Union[AnyTensor, Mapping[str, AnyTensor], Sequence[AnyTensor]],
+    device,
+) -> Union[AnyTensor, Dict[str, AnyTensor], List[AnyTensor]]:
+    """Map varies of input type to device.
+    :param inputs: Inputs to be placed onto device.
+    :param device: The torch device to be placed on.
+    :return: The inputs on the specified device.
+    """
+    
+    import torch
+    
+    if isinstance(inputs, torch.Tensor):
+        return inputs.to(device)
+    elif isinstance(inputs, Mapping):
+        return {k: v.to(device) for k, v in inputs.items()}
+    elif isinstance(inputs, Sequence):
+        return [x.to(device) for x in inputs]
+
+
+def get_device_paddle(device: str):
+    """Get Paddle compute device.
+    :param device: device name.
+    """
+    
+    import paddle
+    
+    # translate our own alias into framework-compatible ones
+    if device == 'cuda':
+        return paddle.CUDAPlace(0)
+    elif device == 'cpu':
+        return paddle.CPUPlace()
+    else:
+        raise ValueError(
+            f'Device {device} not recognized, only "cuda" and "cpu" are accepted'
+        )    
+
+
+def to_device_paddle(
+    inputs: Union[AnyTensor, Mapping[str, AnyTensor], Sequence[AnyTensor]],
+    device,
+) -> Union[AnyTensor, Dict[str, AnyTensor], List[AnyTensor]]:
+    """Map varies of input type to device.
+    :param inputs: Inputs to be placed onto device.
+    :param device: The paddle device to be placed on.
+    :return: The inputs on the specified device.
+    """
+    
+    import paddle
+    
+    if isinstance(inputs, paddle.Tensor):
+        return paddle.to_tensor(inputs, place=device)
+    elif isinstance(inputs, Mapping):
+        return {k: paddle.to_tensor(v, place=device) for k, v in inputs.items()}
+    elif isinstance(inputs, Sequence):
+        return [paddle.to_tensor(x, place=device) for x in inputs]
+
+
+def get_device_keras(device: str):
+    """Get tensorflow compute device.
+
+    :param device: device name.
+    """
+    
+    import tensorflow as tf
+    
+    # translate our own alias into framework-compatible ones
+    if device == 'cuda':
+        device = '/GPU:0'
+    elif device == 'cpu':
+        device = '/CPU:0'
+    return tf.device(device)
+

--- a/finetuner/device.py
+++ b/finetuner/device.py
@@ -1,13 +1,15 @@
 from typing import Dict, List, Mapping, Sequence, Union
+
 from .helper import AnyTensor
+
 
 def get_device_pytorch(device: str):
     """Get Pytorch compute device.
     :param device: device name.
     """
-    
+
     import torch
-    
+
     # translate our own alias into framework-compatible ones
     return torch.device(device)
 
@@ -21,9 +23,9 @@ def to_device_pytorch(
     :param device: The torch device to be placed on.
     :return: The inputs on the specified device.
     """
-    
+
     import torch
-    
+
     if isinstance(inputs, torch.Tensor):
         return inputs.to(device)
     elif isinstance(inputs, Mapping):
@@ -36,9 +38,9 @@ def get_device_paddle(device: str):
     """Get Paddle compute device.
     :param device: device name.
     """
-    
+
     import paddle
-    
+
     # translate our own alias into framework-compatible ones
     if device == 'cuda':
         return paddle.CUDAPlace(0)
@@ -47,7 +49,7 @@ def get_device_paddle(device: str):
     else:
         raise ValueError(
             f'Device {device} not recognized, only "cuda" and "cpu" are accepted'
-        )    
+        )
 
 
 def to_device_paddle(
@@ -59,9 +61,9 @@ def to_device_paddle(
     :param device: The paddle device to be placed on.
     :return: The inputs on the specified device.
     """
-    
+
     import paddle
-    
+
     if isinstance(inputs, paddle.Tensor):
         return paddle.to_tensor(inputs, place=device)
     elif isinstance(inputs, Mapping):
@@ -75,13 +77,12 @@ def get_device_keras(device: str):
 
     :param device: device name.
     """
-    
+
     import tensorflow as tf
-    
+
     # translate our own alias into framework-compatible ones
     if device == 'cuda':
         device = '/GPU:0'
     elif device == 'cpu':
         device = '/CPU:0'
     return tf.device(device)
-

--- a/finetuner/device.py
+++ b/finetuner/device.py
@@ -17,7 +17,7 @@ def get_device_pytorch(device: str):
 def to_device_pytorch(
     inputs: Union[AnyTensor, Mapping[str, AnyTensor], Sequence[AnyTensor]], device
 ) -> Union[AnyTensor, Dict[str, AnyTensor], List[AnyTensor]]:
-    """Map various of input type to device.
+    """Maps various input types to device.
     :param inputs: Inputs to be placed onto device.
     :param device: The torch device to be placed on.
     :return: The inputs on the specified device.
@@ -54,7 +54,7 @@ def get_device_paddle(device: str):
 def to_device_paddle(
     inputs: Union[AnyTensor, Mapping[str, AnyTensor], Sequence[AnyTensor]], device
 ) -> Union[AnyTensor, Dict[str, AnyTensor], List[AnyTensor]]:
-    """Map various of input type to device.
+    """Maps various input types to device.
     :param inputs: Inputs to be placed onto device.
     :param device: The paddle device to be placed on.
     :return: The inputs on the specified device.

--- a/finetuner/device.py
+++ b/finetuner/device.py
@@ -15,10 +15,9 @@ def get_device_pytorch(device: str):
 
 
 def to_device_pytorch(
-    inputs: Union[AnyTensor, Mapping[str, AnyTensor], Sequence[AnyTensor]],
-    device,
+    inputs: Union[AnyTensor, Mapping[str, AnyTensor], Sequence[AnyTensor]], device
 ) -> Union[AnyTensor, Dict[str, AnyTensor], List[AnyTensor]]:
-    """Map varies of input type to device.
+    """Map various of input type to device.
     :param inputs: Inputs to be placed onto device.
     :param device: The torch device to be placed on.
     :return: The inputs on the specified device.
@@ -53,10 +52,9 @@ def get_device_paddle(device: str):
 
 
 def to_device_paddle(
-    inputs: Union[AnyTensor, Mapping[str, AnyTensor], Sequence[AnyTensor]],
-    device,
+    inputs: Union[AnyTensor, Mapping[str, AnyTensor], Sequence[AnyTensor]], device
 ) -> Union[AnyTensor, Dict[str, AnyTensor], List[AnyTensor]]:
-    """Map varies of input type to device.
+    """Map various of input type to device.
     :param inputs: Inputs to be placed onto device.
     :param device: The paddle device to be placed on.
     :return: The inputs on the specified device.
@@ -85,4 +83,8 @@ def get_device_keras(device: str):
         device = '/GPU:0'
     elif device == 'cpu':
         device = '/CPU:0'
+    else:
+        raise ValueError(
+            f'Device {device} not recognized, only "cuda" and "cpu" are accepted'
+        )
     return tf.device(device)

--- a/finetuner/embedding.py
+++ b/finetuner/embedding.py
@@ -46,12 +46,12 @@ def _set_embeddings_keras(
     preprocess_fn: Optional['PreprocFnType'] = None,
     collate_fn: Optional['CollateFnType'] = None,
 ):
-    from .tuner.keras import get_device
+    from .device import get_device_keras
 
     if not collate_fn:
         collate_fn = lambda x: np.array(x)  # noqa
 
-    device = get_device(device)
+    device = get_device_keras(device)
     with device:
         for b in docs.batch(batch_size):
             if preprocess_fn:
@@ -70,9 +70,9 @@ def _set_embeddings_torch(
     preprocess_fn: Optional['PreprocFnType'] = None,
     collate_fn: Optional['CollateFnType'] = None,
 ):
-    from .tuner.pytorch import get_device
+    from .device import get_device_pytorch
 
-    device = get_device(device)
+    device = get_device_pytorch(device)
 
     import torch
 
@@ -102,9 +102,9 @@ def _set_embeddings_paddle(
     preprocess_fn: Optional['PreprocFnType'] = None,
     collate_fn: Optional['CollateFnType'] = None,
 ):
-    from .tuner.paddle import get_device
+    from .device import get_device_paddle
 
-    device = get_device(device)
+    device = get_device_paddle(device)
 
     import paddle
 

--- a/finetuner/excepts.py
+++ b/finetuner/excepts.py
@@ -3,3 +3,7 @@
 
 class DimensionMismatchException(Exception):
     """Dimensionality mismatch given input and output layers."""
+
+
+class DeviceError(Exception):
+    """Model is placed on the wrong device."""

--- a/finetuner/tailor/__init__.py
+++ b/finetuner/tailor/__init__.py
@@ -31,6 +31,7 @@ def to_embedding_model(
     input_dtype: str = 'float32',
     freeze: Union[bool, List[str]] = False,
     projection_head: Optional['AnyDNN'] = None,
+    device: Optional[str] = 'cpu',
     **kwargs
 ) -> 'AnyDNN':
     """Convert a general model from :py:attr:`.model` to an embedding model.
@@ -43,10 +44,12 @@ def to_embedding_model(
     :param input_dtype: The input data type of the DNN model.
     :param freeze: if set as True, will freeze all layers before :py:`attr`:`layer_name`. If set as list of str, will freeze layers by names.
     :param projection_head: Attach a module at the end of model, this module should be always trainable.
+    :param device: The device to which to move the model. Supported options are
+            ``"cpu"`` and ``"cuda"`` (for GPU).
     """
     ft = _get_tailor_class(model)
 
-    return ft(model, input_size, input_dtype).to_embedding_model(
+    return ft(model, input_size, input_dtype, device=device).to_embedding_model(
         layer_name=layer_name,
         projection_head=projection_head,
         freeze=freeze,

--- a/finetuner/tailor/base.py
+++ b/finetuner/tailor/base.py
@@ -19,6 +19,8 @@ class BaseTailor(abc.ABC):
         :param input_size: a sequence of integers defining the shape of the input tensor. Note, batch size is *not* part
             of ``input_size``. It is required for :py:class:`PytorchTailor` and  :py:class:`PaddleTailor`, but not :py:class:`C`
         :param input_dtype: the data type of the input tensor.
+        :param device: The device to which to move the model. Supported options are
+            ``"cpu"`` and ``"cuda"`` (for GPU).
         """
         self._model = model
 

--- a/finetuner/tailor/base.py
+++ b/finetuner/tailor/base.py
@@ -21,7 +21,7 @@ class BaseTailor(abc.ABC):
         :param input_dtype: the data type of the input tensor.
         """
         self._model = model
-        
+
         self._set_device(device)
 
         # multiple inputs to the network
@@ -34,8 +34,7 @@ class BaseTailor(abc.ABC):
     @abc.abstractmethod
     def _set_device(self, device: str) -> None:
         ...
-        
-        
+
     @abc.abstractmethod
     def to_embedding_model(
         self,

--- a/finetuner/tailor/base.py
+++ b/finetuner/tailor/base.py
@@ -11,6 +11,7 @@ class BaseTailor(abc.ABC):
         model: 'AnyDNN',
         input_size: Optional[Tuple[int, ...]] = None,
         input_dtype: str = 'float32',
+        device: Optional[str] = 'cpu',
     ):
         """Tailor converts a general DNN model into an embedding model.
 
@@ -20,6 +21,8 @@ class BaseTailor(abc.ABC):
         :param input_dtype: the data type of the input tensor.
         """
         self._model = model
+        
+        self._set_device(device)
 
         # multiple inputs to the network
         if isinstance(input_size, tuple):
@@ -28,6 +31,11 @@ class BaseTailor(abc.ABC):
         self._input_size = input_size
         self._input_dtype = input_dtype
 
+    @abc.abstractmethod
+    def _set_device(self, device: str) -> None:
+        ...
+        
+        
     @abc.abstractmethod
     def to_embedding_model(
         self,

--- a/finetuner/tailor/keras/__init__.py
+++ b/finetuner/tailor/keras/__init__.py
@@ -123,3 +123,6 @@ class KerasTailor(BaseTailor):
             model = tf.keras.Model(model.input, x)
 
         return model
+   
+    def _set_device(self, device: str) -> None:
+        ...

--- a/finetuner/tailor/keras/__init__.py
+++ b/finetuner/tailor/keras/__init__.py
@@ -123,6 +123,6 @@ class KerasTailor(BaseTailor):
             model = tf.keras.Model(model.input, x)
 
         return model
-   
+
     def _set_device(self, device: str) -> None:
         ...

--- a/finetuner/tailor/paddle/__init__.py
+++ b/finetuner/tailor/paddle/__init__.py
@@ -209,7 +209,9 @@ class PaddleTailor(BaseTailor):
         self._device = get_device_paddle(device)
         for param in self._model.parameters():
             if str(param.place) == 'CUDAPlace(0)':
-                raise DeviceError('Paddle models are expected to be placed on the CPU')
+                raise DeviceError(
+                    'Tailoring a PaddlePaddle model placed on the GPU is currently not supported. Try placing to CPU instead.'
+                )
 
 
 class _Identity(nn.Layer):

--- a/finetuner/tailor/paddle/__init__.py
+++ b/finetuner/tailor/paddle/__init__.py
@@ -6,9 +6,10 @@ import numpy as np
 import paddle
 from paddle import Tensor, nn
 
+from ...device import get_device_paddle, to_device_paddle
+from ...excepts import DeviceError
 from ...helper import is_seq_int
 from ..base import BaseTailor
-from ...device import get_device_paddle, to_device_paddle
 
 if TYPE_CHECKING:
     from ...helper import AnyDNN, LayerInfoType
@@ -203,10 +204,12 @@ class PaddleTailor(BaseTailor):
             return embed_model_with_projection_head
 
         return model
-    
+
     def _set_device(self, device: str) -> None:
         self._device = get_device_paddle(device)
-        self._model.to(self._device)
+        for param in self._model.parameters():
+            if param.place == paddle.CUDAPlace(0):
+                raise DeviceError('Paddle models are expected to be placed on the CPU')
 
 
 class _Identity(nn.Layer):

--- a/finetuner/tailor/paddle/__init__.py
+++ b/finetuner/tailor/paddle/__init__.py
@@ -206,8 +206,6 @@ class PaddleTailor(BaseTailor):
     
     def _set_device(self, device: str) -> None:
         self._device = get_device_paddle(device)
-        print('GET HERE')
-        print(type(self._device))
         self._model.to(self._device)
 
 

--- a/finetuner/tailor/paddle/__init__.py
+++ b/finetuner/tailor/paddle/__init__.py
@@ -208,7 +208,7 @@ class PaddleTailor(BaseTailor):
     def _set_device(self, device: str) -> None:
         self._device = get_device_paddle(device)
         for param in self._model.parameters():
-            if param.place == paddle.CUDAPlace(0):
+            if str(param.place) == 'CUDAPlace(0)':
                 raise DeviceError('Paddle models are expected to be placed on the CPU')
 
 

--- a/finetuner/tailor/paddle/__init__.py
+++ b/finetuner/tailor/paddle/__init__.py
@@ -8,6 +8,7 @@ from paddle import Tensor, nn
 
 from ...helper import is_seq_int
 from ..base import BaseTailor
+from ...device import get_device_paddle, to_device_paddle
 
 if TYPE_CHECKING:
     from ...helper import AnyDNN, LayerInfoType
@@ -90,6 +91,7 @@ class PaddleTailor(BaseTailor):
             paddle.cast(paddle.rand([2, *in_size]), dtype)
             for in_size, dtype in zip(self._input_size, dtypes)
         ]
+        x = to_device_paddle(x, self._device)
 
         # create properties
         summary = OrderedDict()
@@ -201,6 +203,12 @@ class PaddleTailor(BaseTailor):
             return embed_model_with_projection_head
 
         return model
+    
+    def _set_device(self, device: str) -> None:
+        self._device = get_device_paddle(device)
+        print('GET HERE')
+        print(type(self._device))
+        self._model.to(self._device)
 
 
 class _Identity(nn.Layer):

--- a/finetuner/tailor/pytorch/__init__.py
+++ b/finetuner/tailor/pytorch/__init__.py
@@ -6,9 +6,9 @@ import numpy as np
 import torch
 from torch import nn
 
+from ...device import get_device_pytorch, to_device_pytorch
 from ...helper import is_seq_int
 from ..base import BaseTailor
-from ...device import get_device_pytorch, to_device_pytorch
 
 if TYPE_CHECKING:
     from ...helper import AnyDNN, LayerInfoType
@@ -199,7 +199,7 @@ class PytorchTailor(BaseTailor):
             return embed_model_with_projection_head
 
         return model
-    
+
     def _set_device(self, device: str) -> None:
         self._device = get_device_pytorch(device)
         self._model = self._model.to(self._device)

--- a/finetuner/tailor/pytorch/__init__.py
+++ b/finetuner/tailor/pytorch/__init__.py
@@ -8,6 +8,7 @@ from torch import nn
 
 from ...helper import is_seq_int
 from ..base import BaseTailor
+from ...device import get_device_pytorch, to_device_pytorch
 
 if TYPE_CHECKING:
     from ...helper import AnyDNN, LayerInfoType
@@ -82,6 +83,7 @@ class PytorchTailor(BaseTailor):
             torch.rand(2, *in_size).type(dt)
             for in_size, dt in zip(self._input_size, dtypes)
         ]
+        x = to_device_pytorch(x, self._device)
 
         # create properties
         summary = OrderedDict()
@@ -197,3 +199,7 @@ class PytorchTailor(BaseTailor):
             return embed_model_with_projection_head
 
         return model
+    
+    def _set_device(self, device: str) -> None:
+        self._device = get_device_pytorch(device)
+        self._model = self._model.to(self._device)

--- a/finetuner/tuner/keras/__init__.py
+++ b/finetuner/tuner/keras/__init__.py
@@ -8,6 +8,7 @@ from tensorflow.keras.optimizers.schedules import LearningRateSchedule
 
 from ... import __default_tag_key__
 from ..base import BaseLoss, BaseTuner
+from ...device import get_device_keras
 from ..dataset import ClassDataset, SessionDataset
 from ..dataset.datasets import InstanceDataset
 from ..state import TunerState
@@ -153,7 +154,7 @@ class KerasTuner(
         self.state = TunerState(num_epochs=epochs)
         self._trigger_callbacks('on_fit_begin')
 
-        with get_device(self._device_name):
+        with get_device_keras(self._device_name):
             for epoch in range(epochs):
 
                 # Setting here as re-shuffling can change number of batches
@@ -195,15 +196,3 @@ class KerasTuner(
         """
         self.embed_model.save(*args, **kwargs)
 
-
-def get_device(device: str):
-    """Get tensorflow compute device.
-
-    :param device: device name.
-    """
-    # translate our own alias into framework-compatible ones
-    if device == 'cuda':
-        device = '/GPU:0'
-    elif device == 'cpu':
-        device = '/CPU:0'
-    return tf.device(device)

--- a/finetuner/tuner/keras/__init__.py
+++ b/finetuner/tuner/keras/__init__.py
@@ -7,8 +7,8 @@ from tensorflow.keras.optimizers import Optimizer
 from tensorflow.keras.optimizers.schedules import LearningRateSchedule
 
 from ... import __default_tag_key__
-from ..base import BaseLoss, BaseTuner
 from ...device import get_device_keras
+from ..base import BaseLoss, BaseTuner
 from ..dataset import ClassDataset, SessionDataset
 from ..dataset.datasets import InstanceDataset
 from ..state import TunerState
@@ -195,4 +195,3 @@ class KerasTuner(
             model.
         """
         self.embed_model.save(*args, **kwargs)
-

--- a/finetuner/tuner/paddle/__init__.py
+++ b/finetuner/tuner/paddle/__init__.py
@@ -9,6 +9,7 @@ from paddle.optimizer.lr import LRScheduler
 
 from ... import __default_tag_key__
 from ..base import BaseTuner
+from ...device import get_device_paddle, to_device_paddle
 from ..state import TunerState
 from . import losses
 from .datasets import PaddleClassDataset, PaddleInstanceDataset, PaddleSessionDataset
@@ -17,18 +18,6 @@ if TYPE_CHECKING:
     from docarray import DocumentArray
 
     from ...helper import CollateFnType, PreprocFnType
-
-
-def _to_device(
-    inputs: Union[paddle.Tensor, Mapping[str, paddle.Tensor], Sequence[paddle.Tensor]],
-    device,
-) -> Union[paddle.Tensor, Dict[str, paddle.Tensor], List[paddle.Tensor]]:
-    if isinstance(inputs, paddle.Tensor):
-        return paddle.to_tensor(inputs, place=device)
-    elif isinstance(inputs, Mapping):
-        return {k: paddle.to_tensor(v, place=device) for k, v in inputs.items()}
-    elif isinstance(inputs, Sequence):
-        return [paddle.to_tensor(x, place=device) for x in inputs]
 
 
 class PaddleTuner(BaseTuner[nn.Layer, DataLoader, Optimizer, LRScheduler]):
@@ -86,7 +75,7 @@ class PaddleTuner(BaseTuner[nn.Layer, DataLoader, Optimizer, LRScheduler]):
 
     def _move_model_to_device(self):
         """Move the model to device and set device."""
-        self.device = get_device(self._device_name)
+        self.device = get_device_paddle(self._device_name)
         self._embed_model.to(device=self.device)
 
     def _default_configure_optimizer(self, model: nn.Layer) -> Optimizer:
@@ -106,8 +95,8 @@ class PaddleTuner(BaseTuner[nn.Layer, DataLoader, Optimizer, LRScheduler]):
 
             self._trigger_callbacks('on_train_batch_begin')
 
-            inputs = _to_device(inputs, self.device)
-            labels = _to_device(labels, self.device)
+            inputs = to_device_paddle(inputs, self.device)
+            labels = to_device_paddle(labels, self.device)
 
             embeddings = self.embed_model(inputs)
             loss = self._loss(embeddings, labels)
@@ -132,8 +121,8 @@ class PaddleTuner(BaseTuner[nn.Layer, DataLoader, Optimizer, LRScheduler]):
             self.state.batch_index = idx
             self._trigger_callbacks('on_val_batch_begin')
 
-            inputs = _to_device(inputs, self.device)
-            labels = _to_device(labels, self.device)
+            inputs = to_device_paddle(inputs, self.device)
+            labels = to_device_paddle(labels, self.device)
 
             embeddings = self.embed_model(inputs)
             loss = self._loss(embeddings, labels)
@@ -222,19 +211,3 @@ class PaddleTuner(BaseTuner[nn.Layer, DataLoader, Optimizer, LRScheduler]):
         :param kwargs: Keyword arguments to pass to ``paddle.save`` function.
         """
         paddle.save(self.embed_model.state_dict(), *args, **kwargs)
-
-
-def get_device(device: str):
-    """Get Paddle compute device.
-
-    :param device: device name.
-    """
-    # translate our own alias into framework-compatible ones
-    if device == 'cuda':
-        return paddle.CUDAPlace(0)
-    elif device == 'cpu':
-        return paddle.CPUPlace()
-    else:
-        raise ValueError(
-            f'Device {device} not recognized, only "cuda" and "cpu" are accepted'
-        )

--- a/finetuner/tuner/paddle/__init__.py
+++ b/finetuner/tuner/paddle/__init__.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Dict, List, Mapping, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import paddle
 from paddle import nn
@@ -8,8 +8,8 @@ from paddle.optimizer import Adam, Optimizer
 from paddle.optimizer.lr import LRScheduler
 
 from ... import __default_tag_key__
-from ..base import BaseTuner
 from ...device import get_device_paddle, to_device_paddle
+from ..base import BaseTuner
 from ..state import TunerState
 from . import losses
 from .datasets import PaddleClassDataset, PaddleInstanceDataset, PaddleSessionDataset

--- a/finetuner/tuner/pytorch/__init__.py
+++ b/finetuner/tuner/pytorch/__init__.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Dict, List, Mapping, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import torch
 from torch import nn
@@ -8,8 +8,8 @@ from torch.utils.data._utils.collate import default_collate
 from torch.utils.data.dataloader import DataLoader
 
 from ... import __default_tag_key__
-from ..base import BaseTuner
 from ...device import get_device_pytorch, to_device_pytorch
+from ..base import BaseTuner
 from ..state import TunerState
 from . import losses
 from .datasets import PytorchClassDataset, PytorchInstanceDataset, PytorchSessionDataset
@@ -214,4 +214,3 @@ class PytorchTuner(BaseTuner[nn.Module, DataLoader, Optimizer, _LRScheduler]):
         :param kwargs: Keyword arguments to pass to ``torch.save`` function.
         """
         torch.save(self.embed_model.state_dict(), *args, **kwargs)
-

--- a/finetuner/tuner/pytorch/__init__.py
+++ b/finetuner/tuner/pytorch/__init__.py
@@ -9,6 +9,7 @@ from torch.utils.data.dataloader import DataLoader
 
 from ... import __default_tag_key__
 from ..base import BaseTuner
+from ...device import get_device_pytorch, to_device_pytorch
 from ..state import TunerState
 from . import losses
 from .datasets import PytorchClassDataset, PytorchInstanceDataset, PytorchSessionDataset
@@ -17,18 +18,6 @@ if TYPE_CHECKING:
     from docarray import DocumentArray
 
     from ...helper import CollateFnType, PreprocFnType
-
-
-def _to_device(
-    inputs: Union[torch.Tensor, Mapping[str, torch.Tensor], Sequence[torch.Tensor]],
-    device: torch.device,
-) -> Union[torch.Tensor, Dict[str, torch.Tensor], List[torch.Tensor]]:
-    if isinstance(inputs, torch.Tensor):
-        return inputs.to(device)
-    elif isinstance(inputs, Mapping):
-        return {k: v.to(device) for k, v in inputs.items()}
-    elif isinstance(inputs, Sequence):
-        return [x.to(device) for x in inputs]
 
 
 class CollateAll:
@@ -91,7 +80,7 @@ class PytorchTuner(BaseTuner[nn.Module, DataLoader, Optimizer, _LRScheduler]):
 
     def _move_model_to_device(self):
         """Move the model to device and set device."""
-        self.device = get_device(self._device_name)
+        self.device = get_device_pytorch(self._device_name)
         self._embed_model = self._embed_model.to(self.device)
 
     def _default_configure_optimizer(self, model: nn.Module) -> Optimizer:
@@ -112,8 +101,8 @@ class PytorchTuner(BaseTuner[nn.Module, DataLoader, Optimizer, _LRScheduler]):
                 self.state.learning_rates[f'group_{param_idx}'] = param_group['lr']
 
             self._trigger_callbacks('on_train_batch_begin')
-            inputs = _to_device(inputs, self.device)
-            labels = _to_device(labels, self.device)
+            inputs = to_device_pytorch(inputs, self.device)
+            labels = to_device_pytorch(labels, self.device)
 
             embeddings = self.embed_model(inputs)
             loss = self._loss(embeddings, labels)
@@ -137,8 +126,8 @@ class PytorchTuner(BaseTuner[nn.Module, DataLoader, Optimizer, _LRScheduler]):
             self.state.batch_index = idx
             self._trigger_callbacks('on_val_batch_begin')
 
-            inputs = _to_device(inputs, self.device)
-            labels = _to_device(labels, self.device)
+            inputs = to_device_pytorch(inputs, self.device)
+            labels = to_device_pytorch(labels, self.device)
 
             with torch.no_grad():
                 embeddings = self.embed_model(inputs)
@@ -226,11 +215,3 @@ class PytorchTuner(BaseTuner[nn.Module, DataLoader, Optimizer, _LRScheduler]):
         """
         torch.save(self.embed_model.state_dict(), *args, **kwargs)
 
-
-def get_device(device: str):
-    """Get Pytorch compute device.
-
-    :param device: device name.
-    """
-    # translate our own alias into framework-compatible ones
-    return torch.device(device)

--- a/tests/unit/tailor/keras/test_keras.py
+++ b/tests/unit/tailor/keras/test_keras.py
@@ -48,11 +48,11 @@ def test_to_embedding_model(tf_model, layer_name, expected_output_shape):
 def test_to_embedding_model_with_cuda_tensor(tf_simple_cnn_model):
     device = tf.device('gpu')
 
-    keras_tailor = KerasTailor(device='cuda')
-
     model = tf_simple_cnn_model.to(device)
 
-    model = keras_tailor.to_embedding_model(model)
+    keras_tailor = KerasTailor(model, device='cuda')
+
+    model = keras_tailor.to_embedding_model()
     assert model
 
 

--- a/tests/unit/tailor/keras/test_keras.py
+++ b/tests/unit/tailor/keras/test_keras.py
@@ -44,18 +44,6 @@ def test_to_embedding_model(tf_model, layer_name, expected_output_shape):
     assert model.output_shape == expected_output_shape
 
 
-@pytest.mark.gpu
-def test_to_embedding_model_with_cuda_tensor(tf_simple_cnn_model):
-    device = tf.device('gpu')
-
-    model = tf_simple_cnn_model.to(device)
-
-    keras_tailor = KerasTailor(model, device='cuda')
-
-    model = keras_tailor.to_embedding_model()
-    assert model
-
-
 def test_weights_preserved_given_pretrained_model(tf_vgg16_cnn_model):
     weights = tf_vgg16_cnn_model.layers[0].get_weights()
     keras_tailor = KerasTailor(tf_vgg16_cnn_model)

--- a/tests/unit/tailor/keras/test_keras.py
+++ b/tests/unit/tailor/keras/test_keras.py
@@ -44,6 +44,18 @@ def test_to_embedding_model(tf_model, layer_name, expected_output_shape):
     assert model.output_shape == expected_output_shape
 
 
+@pytest.mark.gpu
+def test_to_embedding_model_with_cuda_tensor(tf_simple_cnn_model):
+    device = tf.device('gpu')
+
+    keras_tailor = KerasTailor(device='cuda')
+
+    model = tf_simple_cnn_model.to(device)
+
+    model = keras_tailor.to_embedding_model(model)
+    assert model
+
+
 def test_weights_preserved_given_pretrained_model(tf_vgg16_cnn_model):
     weights = tf_vgg16_cnn_model.layers[0].get_weights()
     keras_tailor = KerasTailor(tf_vgg16_cnn_model)

--- a/tests/unit/tailor/paddle/test_paddle.py
+++ b/tests/unit/tailor/paddle/test_paddle.py
@@ -3,6 +3,7 @@ import paddle
 import paddle.nn as nn
 import pytest
 
+from finetuner.excepts import DeviceError
 from finetuner.tailor.paddle import PaddleTailor
 
 
@@ -210,6 +211,19 @@ def test_to_embedding_model(
     np.testing.assert_array_equal(weight, weight_after_convert)
     out = model(paddle.cast(paddle.rand(input_), input_dtype))
     assert list(out.shape) == expected_output_shape
+
+
+@pytest.mark.gpu
+def test_to_embedding_model_with_cuda_tensor(paddle_simple_cnn_model):
+
+    pytorch_tailor = PaddleTailor(
+        input_size=(1, 28, 28), input_dtype='float32', device='cuda'
+    )
+    model = paddle_simple_cnn_model.to(paddle.CUDAPlace(0))
+    with pytest.raises(DeviceError):
+        model = pytorch_tailor.to_embedding_model(model)
+
+    assert model
 
 
 def test_paddle_lstm_model_parser():

--- a/tests/unit/tailor/paddle/test_paddle.py
+++ b/tests/unit/tailor/paddle/test_paddle.py
@@ -216,12 +216,14 @@ def test_to_embedding_model(
 @pytest.mark.gpu
 def test_to_embedding_model_with_cuda_tensor(paddle_simple_cnn_model):
 
-    pytorch_tailor = PaddleTailor(
-        input_size=(1, 28, 28), input_dtype='float32', device='cuda'
-    )
     model = paddle_simple_cnn_model.to(paddle.CUDAPlace(0))
+
     with pytest.raises(DeviceError):
-        model = pytorch_tailor.to_embedding_model(model)
+        paddle_tailor = PaddleTailor(
+            model, input_size=(1, 28, 28), input_dtype='float32', device='cuda'
+        )
+
+        model = paddle_tailor.to_embedding_model()
 
     assert model
 

--- a/tests/unit/tailor/paddle/test_paddle.py
+++ b/tests/unit/tailor/paddle/test_paddle.py
@@ -225,8 +225,6 @@ def test_to_embedding_model_with_cuda_tensor(paddle_simple_cnn_model):
 
         model = paddle_tailor.to_embedding_model()
 
-    assert model
-
 
 def test_paddle_lstm_model_parser():
     user_model = paddle.nn.Sequential(

--- a/tests/unit/tailor/paddle/test_paddle.py
+++ b/tests/unit/tailor/paddle/test_paddle.py
@@ -216,7 +216,8 @@ def test_to_embedding_model(
 @pytest.mark.gpu
 def test_to_embedding_model_with_cuda_tensor(paddle_simple_cnn_model):
 
-    model = paddle_simple_cnn_model.to(paddle.CUDAPlace(0))
+    model = paddle_simple_cnn_model
+    model.to(paddle.CUDAPlace(0))
 
     with pytest.raises(DeviceError):
         paddle_tailor = PaddleTailor(

--- a/tests/unit/tailor/pytorch/test_pytorch.py
+++ b/tests/unit/tailor/pytorch/test_pytorch.py
@@ -41,7 +41,6 @@ def test_trim_fail_given_unexpected_layer_idx(
             model=torch_model,
             input_size=input_size,
             input_dtype=input_dtype,
-            device='cuda',
         )
         paddle_tailor.to_embedding_model(
             freeze=False,

--- a/tests/unit/tailor/pytorch/test_pytorch.py
+++ b/tests/unit/tailor/pytorch/test_pytorch.py
@@ -41,6 +41,7 @@ def test_trim_fail_given_unexpected_layer_idx(
             model=torch_model,
             input_size=input_size,
             input_dtype=input_dtype,
+            device='cuda',
         )
         paddle_tailor.to_embedding_model(
             freeze=False,
@@ -114,6 +115,20 @@ def test_to_embedding_model(
         input_ = input_.type(torch.LongTensor)
     out = model(input_)
     assert list(out.size()) == expected_output_shape
+
+
+@pytest.mark.gpu
+def test_to_embedding_model_with_cuda_tensor(torch_simple_cnn_model):
+    device = torch.device('cuda:0')
+
+    pytorch_tailor = PytorchTailor(
+        input_size=(1, 28, 28), input_dtype='float32', device='cuda'
+    )
+
+    model = torch_simple_cnn_model.to(device)
+
+    model = pytorch_tailor.to_embedding_model(model)
+    assert model
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/tailor/pytorch/test_pytorch.py
+++ b/tests/unit/tailor/pytorch/test_pytorch.py
@@ -121,13 +121,13 @@ def test_to_embedding_model(
 def test_to_embedding_model_with_cuda_tensor(torch_simple_cnn_model):
     device = torch.device('cuda:0')
 
-    pytorch_tailor = PytorchTailor(
-        input_size=(1, 28, 28), input_dtype='float32', device='cuda'
-    )
-
     model = torch_simple_cnn_model.to(device)
 
-    model = pytorch_tailor.to_embedding_model(model)
+    pytorch_tailor = PytorchTailor(
+        model, input_size=(1, 28, 28), input_dtype='float32', device='cuda'
+    )
+
+    model = pytorch_tailor.to_embedding_model()
     assert model
 
 


### PR DESCRIPTION
This is a draft to address issue #368. There is still an issue which occurs if specific paddle models (e.g. LSTM models) are assigned to a device with the paddle.fluid.dygraph.layers.to function.