### PR TITLE
fix(qabot): hide the slot elements on the docs page

### DIFF
--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -192,12 +192,14 @@
         title="Finetuner Bot"
         description="Finetuning better embedding on neural search tasks"
     >
-        <dl>
-            <dt>You can ask questions about our docs. Try:</dt>
-            <dd>What is Tailor?</dd>
-            <dd>How can I freeze layers?</dd>
-            <dd>What is the input data format for finetuner?</dd>
-        </dl>
+        <template>
+            <dl>
+                <dt>You can ask questions about our docs. Try:</dt>
+                <dd>What is Tailor?</dd>
+                <dd>How can I freeze layers?</dd>
+                <dd>What is the input data format for finetuner?</dd>
+            </dl>
+        </template>
     </qa-bot>
 </div>
 <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=e0caedb8-a833-4e85-983d-d3394a5f16d2" />


### PR DESCRIPTION
Add a template to prevent the qabot slot elements from showing on the docs pages.