### PR TITLE
refactor: remove path and dotenv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Remove dependencies for `path` and `dotenv`. ([#444](https://github.com/jina-ai/finetuner/pull/444))
+- Remove `path` and `dotenv` as dependencies. ([#444](https://github.com/jina-ai/finetuner/pull/444))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Remove dependencies for `path` and `dotenv`. ([#444](https://github.com/jina-ai/finetuner/pull/444))
+
 ### Changed
 
 ### Fixed

--- a/finetuner/__init__.py
+++ b/finetuner/__init__.py
@@ -3,7 +3,6 @@ import os
 from typing import Any, Dict, List, Optional, Union
 
 from docarray import DocumentArray
-from dotenv import load_dotenv
 from rich.console import Console
 from rich.table import Table
 
@@ -28,7 +27,6 @@ from finetuner.finetuner import Finetuner
 __version__ = '0.2.1'
 
 
-load_dotenv()
 ft = Finetuner()
 
 

--- a/finetuner/client/base.py
+++ b/finetuner/client/base.py
@@ -2,7 +2,6 @@ import os
 from typing import List, Optional, Union
 
 import requests
-from path import Path
 
 import hubble
 from finetuner.client.exception import FinetunerServerError
@@ -24,7 +23,7 @@ class _BaseClient:
     """
 
     def __init__(self):
-        self._base_url = Path(os.environ.get(HOST))
+        self._base_url = os.environ.get(HOST)
         self._session = self._get_client_session()
         self.hubble_client = hubble.Client(max_retries=None, jsonify=True)
         self.hubble_user_id = self._get_hubble_user_id()
@@ -43,6 +42,10 @@ class _BaseClient:
         api_token = TOKEN_PREFIX + str(hubble.Auth.get_auth_token())
         session.headers.update({CHARSET: UTF_8, AUTHORIZATION: api_token})
         return session
+
+    @staticmethod
+    def _construct_url(*args) -> str:
+        return '/'.join(args)
 
     def _handle_request(
         self,

--- a/finetuner/client/client.py
+++ b/finetuner/client/client.py
@@ -33,7 +33,7 @@ class FinetunerV1Client(_BaseClient):
         :param description: Optional description of the experiment.
         :return: Created experiment.
         """
-        url = self._base_url / API_VERSION / EXPERIMENTS
+        url = self._construct_url(self._base_url, API_VERSION, EXPERIMENTS)
         return self._handle_request(
             url=url, method=POST, json_data={NAME: name, DESCRIPTION: description}
         )
@@ -44,7 +44,7 @@ class FinetunerV1Client(_BaseClient):
         :param name: The name of the experiment.
         :return: Requested experiment.
         """
-        url = self._base_url / API_VERSION / EXPERIMENTS / name
+        url = self._construct_url(self._base_url, API_VERSION, EXPERIMENTS, name)
         return self._handle_request(url=url, method=GET)
 
     def list_experiments(self) -> List[dict]:
@@ -52,7 +52,7 @@ class FinetunerV1Client(_BaseClient):
 
         :return: List of all experiments.
         """
-        url = self._base_url / API_VERSION / EXPERIMENTS
+        url = self._construct_url(self._base_url, API_VERSION, EXPERIMENTS)
         return self._handle_request(url=url, method=GET)
 
     def delete_experiment(self, name: str) -> dict:
@@ -61,7 +61,7 @@ class FinetunerV1Client(_BaseClient):
         :param name: The name of the experiment.
         :return: Experiment to be deleted.
         """
-        url = self._base_url / API_VERSION / EXPERIMENTS / name
+        url = self._construct_url(self._base_url, API_VERSION, EXPERIMENTS, name)
         return self._handle_request(url=url, method=DELETE)
 
     def delete_experiments(self) -> List[dict]:
@@ -69,7 +69,7 @@ class FinetunerV1Client(_BaseClient):
 
         :return: Experiments to be deleted.
         """
-        url = self._base_url / API_VERSION / EXPERIMENTS
+        url = self._construct_url(self._base_url, API_VERSION, EXPERIMENTS)
         return self._handle_request(url=url, method=DELETE)
 
     """ Run API """
@@ -81,13 +81,8 @@ class FinetunerV1Client(_BaseClient):
         :param run_name: The name of the run.
         :return: Requested run.
         """
-        url = (
-            self._base_url
-            / API_VERSION
-            / EXPERIMENTS
-            / experiment_name
-            / RUNS
-            / run_name
+        url = self._construct_url(
+            self._base_url, API_VERSION, EXPERIMENTS, experiment_name, RUNS, run_name
         )
         return self._handle_request(url=url, method=GET)
 
@@ -106,7 +101,9 @@ class FinetunerV1Client(_BaseClient):
             target_experiments = [experiment_name]
         response = []
         for experiment_name in target_experiments:
-            url = self._base_url / API_VERSION / EXPERIMENTS / experiment_name / RUNS
+            url = self._construct_url(
+                self._base_url, API_VERSION, EXPERIMENTS, experiment_name, RUNS
+            )
             response.extend(self._handle_request(url=url, method=GET))
         return response
 
@@ -117,13 +114,8 @@ class FinetunerV1Client(_BaseClient):
         :param run_name: The name of the run.
         :return: Deleted run.
         """
-        url = (
-            self._base_url
-            / API_VERSION
-            / EXPERIMENTS
-            / experiment_name
-            / RUNS
-            / run_name
+        url = self._construct_url(
+            self._base_url, API_VERSION, EXPERIMENTS, experiment_name, RUNS, run_name
         )
         return self._handle_request(url=url, method=DELETE)
 
@@ -133,7 +125,9 @@ class FinetunerV1Client(_BaseClient):
         :param experiment_name: The name of the experiment.
         :return: List of all deleted runs.
         """
-        url = self._base_url / API_VERSION / EXPERIMENTS / experiment_name / RUNS
+        url = self._construct_url(
+            self._base_url, API_VERSION, EXPERIMENTS, experiment_name, RUNS
+        )
         return self._handle_request(url=url, method=DELETE)
 
     def get_run_status(self, experiment_name: str, run_name: str) -> dict:
@@ -143,14 +137,14 @@ class FinetunerV1Client(_BaseClient):
         :param run_name: The name of the run.
         :return: Run status.
         """
-        url = (
-            self._base_url
-            / API_VERSION
-            / EXPERIMENTS
-            / experiment_name
-            / RUNS
-            / run_name
-            / STATUS
+        url = self._construct_url(
+            self._base_url,
+            API_VERSION,
+            EXPERIMENTS,
+            experiment_name,
+            RUNS,
+            run_name,
+            STATUS,
         )
         return self._handle_request(url=url, method=GET)
 
@@ -161,14 +155,14 @@ class FinetunerV1Client(_BaseClient):
         :param run_name: The name of the run.
         :return: Run logs.
         """
-        url = (
-            self._base_url
-            / API_VERSION
-            / EXPERIMENTS
-            / experiment_name
-            / RUNS
-            / run_name
-            / LOGS
+        url = self._construct_url(
+            self._base_url,
+            API_VERSION,
+            EXPERIMENTS,
+            experiment_name,
+            RUNS,
+            run_name,
+            LOGS,
         )
         return self._handle_request(url=url, method=GET)
 
@@ -192,7 +186,9 @@ class FinetunerV1Client(_BaseClient):
         :param gpus: The number of GPUs to use.
         :return: Created run.
         """
-        url = self._base_url / API_VERSION / EXPERIMENTS / experiment_name / RUNS
+        url = self._construct_url(
+            self._base_url, API_VERSION, EXPERIMENTS, experiment_name, RUNS
+        )
         return self._handle_request(
             url=url,
             method=POST,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 docarray[common]==0.13.19
 jina-hubble-sdk==0.5.1
 path==16.4.0
-python-dotenv==0.19.2
 requests==2.27.1
 rich==12.4.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 docarray[common]==0.13.19
 jina-hubble-sdk==0.5.1
-path==16.4.0
 requests==2.27.1
 rich==12.4.4

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -34,6 +34,9 @@ def finetuner_mocker(mocker):
         print('Successfully logged in to Hubble!')
 
     def get_auth_token():
+        os.environ['JINA_AUTH_TOKEN'] = '5fb009f645b3c476aa285afd135b25f4'
+        if not os.environ.get('JINA_AUTH_TOKEN'):
+            raise ValueError('Please set `JINA_AUTH_TOKEN` as an environment variable.')
         return os.environ.get('JINA_AUTH_TOKEN')
 
     mocker.patch.object(hubble, 'login', hubble_login_mocker)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -34,7 +34,6 @@ def finetuner_mocker(mocker):
         print('Successfully logged in to Hubble!')
 
     def get_auth_token():
-        os.environ['JINA_AUTH_TOKEN'] = '5fb009f645b3c476aa285afd135b25f4'
         if not os.environ.get('JINA_AUTH_TOKEN'):
             raise ValueError('Please set `JINA_AUTH_TOKEN` as an environment variable.')
         return os.environ.get('JINA_AUTH_TOKEN')

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -25,6 +25,9 @@ def _create_base_mocker(mocker):
         print('Successfully logged in to Hubble!')
 
     def get_auth_token():
+        os.environ['JINA_AUTH_TOKEN'] = '5fb009f645b3c476aa285afd135b25f4'
+        if not os.environ.get('JINA_AUTH_TOKEN'):
+            raise ValueError('Please set `JINA_AUTH_TOKEN` as an environment variable.')
         return os.environ.get('JINA_AUTH_TOKEN')
 
     mocker.patch.object(hubble, 'login', hubble_login_mocker)

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -25,7 +25,6 @@ def _create_base_mocker(mocker):
         print('Successfully logged in to Hubble!')
 
     def get_auth_token():
-        os.environ['JINA_AUTH_TOKEN'] = '5fb009f645b3c476aa285afd135b25f4'
         if not os.environ.get('JINA_AUTH_TOKEN'):
             raise ValueError('Please set `JINA_AUTH_TOKEN` as an environment variable.')
         return os.environ.get('JINA_AUTH_TOKEN')

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -17,38 +17,42 @@ from finetuner.experiment import Experiment
 
 def test_create_experiment(client_mocker, name='name'):
     response = client_mocker.create_experiment(name)
-    assert response['url'] == client_mocker._base_url / API_VERSION / EXPERIMENTS
+    assert response['url'] == client_mocker._construct_url(
+        client_mocker._base_url, API_VERSION, EXPERIMENTS
+    )
     assert response['method'] == POST
     assert response['json_data'][NAME] == name
 
 
 def test_get_experiment(client_mocker, name='name'):
     sent_request = client_mocker.get_experiment(name)
-    assert (
-        sent_request['url']
-        == client_mocker._base_url / API_VERSION / EXPERIMENTS / name
+    assert sent_request['url'] == client_mocker._construct_url(
+        client_mocker._base_url, API_VERSION, EXPERIMENTS, name
     )
     assert sent_request['method'] == GET
 
 
 def test_list_experiments(client_mocker):
     sent_request = client_mocker.list_experiments()
-    assert sent_request['url'] == client_mocker._base_url / API_VERSION / EXPERIMENTS
+    assert sent_request['url'] == client_mocker._construct_url(
+        client_mocker._base_url, API_VERSION, EXPERIMENTS
+    )
     assert sent_request['method'] == GET
 
 
 def test_delete_experiment(client_mocker, name='name'):
     sent_request = client_mocker.delete_experiment(name)
-    assert (
-        sent_request['url']
-        == client_mocker._base_url / API_VERSION / EXPERIMENTS / name
+    assert sent_request['url'] == client_mocker._construct_url(
+        client_mocker._base_url, API_VERSION, EXPERIMENTS, name
     )
     assert sent_request['method'] == DELETE
 
 
 def test_delete_experiments(client_mocker):
     sent_request = client_mocker.delete_experiments()
-    assert sent_request['url'] == client_mocker._base_url / API_VERSION / EXPERIMENTS
+    assert sent_request['url'] == client_mocker._construct_url(
+        client_mocker._base_url, API_VERSION, EXPERIMENTS
+    )
     assert sent_request['method'] == DELETE
 
 
@@ -67,9 +71,8 @@ def test_create_run(client_mocker, experiment_name='exp', run_name='run'):
         cpus=1,
         gpus=1,
     )
-    assert (
-        sent_request['url']
-        == client_mocker._base_url / API_VERSION / EXPERIMENTS / experiment_name / RUNS
+    assert sent_request['url'] == client_mocker._construct_url(
+        client_mocker._base_url, API_VERSION, EXPERIMENTS, experiment_name, RUNS
     )
     assert sent_request['method'] == POST
     assert sent_request['json_data'][NAME] == run_name
@@ -82,14 +85,13 @@ def test_get_run(client_mocker, experiment_name='exp', run_name='run1'):
     sent_request = client_mocker.get_run(
         experiment_name=experiment_name, run_name=run_name
     )
-    assert (
-        sent_request['url']
-        == client_mocker._base_url
-        / API_VERSION
-        / EXPERIMENTS
-        / experiment_name
-        / RUNS
-        / run_name
+    assert sent_request['url'] == client_mocker._construct_url(
+        client_mocker._base_url,
+        API_VERSION,
+        EXPERIMENTS,
+        experiment_name,
+        RUNS,
+        run_name,
     )
     assert sent_request['method'] == GET
 
@@ -98,23 +100,21 @@ def test_delete_run(client_mocker, experiment_name='exp', run_name='run1'):
     sent_request = client_mocker.delete_run(
         experiment_name=experiment_name, run_name=run_name
     )
-    assert (
-        sent_request['url']
-        == client_mocker._base_url
-        / API_VERSION
-        / EXPERIMENTS
-        / experiment_name
-        / RUNS
-        / run_name
+    assert sent_request['url'] == client_mocker._construct_url(
+        client_mocker._base_url,
+        API_VERSION,
+        EXPERIMENTS,
+        experiment_name,
+        RUNS,
+        run_name,
     )
     assert sent_request['method'] == DELETE
 
 
 def test_delete_runs(client_mocker, experiment_name='exp'):
     sent_request = client_mocker.delete_runs(experiment_name=experiment_name)
-    assert (
-        sent_request['url']
-        == client_mocker._base_url / API_VERSION / EXPERIMENTS / experiment_name / RUNS
+    assert sent_request['url'] == client_mocker._construct_url(
+        client_mocker._base_url, API_VERSION, EXPERIMENTS, experiment_name, RUNS
     )
     assert sent_request['method'] == DELETE
 
@@ -123,15 +123,14 @@ def test_get_run_status(client_mocker, experiment_name='exp', run_name='run1'):
     sent_request = client_mocker.get_run_status(
         experiment_name=experiment_name, run_name=run_name
     )
-    assert (
-        sent_request['url']
-        == client_mocker._base_url
-        / API_VERSION
-        / EXPERIMENTS
-        / experiment_name
-        / RUNS
-        / run_name
-        / STATUS
+    assert sent_request['url'] == client_mocker._construct_url(
+        client_mocker._base_url,
+        API_VERSION,
+        EXPERIMENTS,
+        experiment_name,
+        RUNS,
+        run_name,
+        STATUS,
     )
     assert sent_request['method'] == GET
 
@@ -140,14 +139,13 @@ def test_get_run_logs(client_mocker, experiment_name='exp', run_name='run1'):
     sent_request = client_mocker.get_run_logs(
         experiment_name=experiment_name, run_name=run_name
     )
-    assert (
-        sent_request['url']
-        == client_mocker._base_url
-        / API_VERSION
-        / EXPERIMENTS
-        / experiment_name
-        / RUNS
-        / run_name
-        / LOGS
+    assert sent_request['url'] == client_mocker._construct_url(
+        client_mocker._base_url,
+        API_VERSION,
+        EXPERIMENTS,
+        experiment_name,
+        RUNS,
+        run_name,
+        LOGS,
     )
     assert sent_request['method'] == GET


### PR DESCRIPTION
Closes https://github.com/jina-ai/finetuner/issues/445

Removes `path` and `dotenv` from the requirements.