### PR TITLE
refactor: use prod environment by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Change default registry to prod for api and hubble. ([#447](https://github.com/jina-ai/finetuner/pull/447))
+
 ### Fixed
 
 ## 0.2.1 - 2022-06-13

--- a/finetuner/constants.py
+++ b/finetuner/constants.py
@@ -5,10 +5,10 @@ NAME = 'name'
 HUBBLE_USER_ID = '_id'
 ID = 'id'
 
-HOST = 'HOST'
+HOST = 'JINA_FINETUNER_REGISTRY'
 HUBBLE_REGISTRY = 'JINA_HUBBLE_REGISTRY'
-DEFAULT_FINETUNER_HOST = 'https://api-staging.finetuner.fit'
-DEFAULT_HUBBLE_REGISTRY = 'https://apihubble.staging.jina.ai'
+DEFAULT_FINETUNER_HOST = 'https://api.finetuner.fit'
+DEFAULT_HUBBLE_REGISTRY = 'https://apihubble.jina.ai'
 
 CONFIG = 'config'
 DEVICE = 'device'

--- a/finetuner/constants.py
+++ b/finetuner/constants.py
@@ -8,7 +8,7 @@ ID = 'id'
 HOST = 'JINA_FINETUNER_REGISTRY'
 HUBBLE_REGISTRY = 'JINA_HUBBLE_REGISTRY'
 DEFAULT_FINETUNER_HOST = 'https://api.finetuner.fit'
-DEFAULT_HUBBLE_REGISTRY = 'https://apihubble.jina.ai'
+DEFAULT_HUBBLE_REGISTRY = 'https://api.hubble.jina.ai'
 
 CONFIG = 'config'
 DEVICE = 'device'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,8 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def overwrite_hubble_registry():
+    os.environ['JINA_FINETUNER_REGISTRY'] = 'https://api-staging.finetuner.fit'
     os.environ['JINA_HUBBLE_REGISTRY'] = 'https://apihubble.staging.jina.ai'
     yield
     del os.environ['JINA_HUBBLE_REGISTRY']
+    del os.environ['JINA_FINETUNER_REGISTRY']


### PR DESCRIPTION
after the API prod deployment, before beta testing, we need to change the default API and Hubble registry to prod. While testing, use staging for integration test.

link to the internal issue: https://github.com/jina-ai/finetuner-api/issues/87