### PR TITLE
chore: 0.2.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
 ## [Unreleased] - 2022-MM-DD
+
+### Added
+
+### Removed
+
+### Changed
+
+### Fixed
+
+
+## 0.2.2 - 2022-06-16
 
 ### Added
 

--- a/docs/2_step_by_step/2_1_install.md
+++ b/docs/2_step_by_step/2_1_install.md
@@ -27,5 +27,5 @@ Check your installation with:
 ```pycon
 >>> import finetuner
 >>> finetuner.__version__
-'0.2.1'
+'0.2.2'
 ```

--- a/finetuner/__init__.py
+++ b/finetuner/__init__.py
@@ -24,7 +24,7 @@ from finetuner import callback, models
 from finetuner.experiment import Experiment
 from finetuner.finetuner import Finetuner
 
-__version__ = '0.2.1'
+__version__ = '0.2.2'
 
 
 ft = Finetuner()


### PR DESCRIPTION
this patch release has changed the default host from staging to prod, readme polishment and dependency clean up.