### PR TITLE
chore: remove time column from table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Various updates on style, how-to and templates. ([#462](https://github.com/jina-ai/finetuner/pull/462))
 
+- Remove time column from Readme table. ([#468](https://github.com/jina-ai/finetuner/pull/468))
+
 ### Fixed
 
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ The following table demonstrates what you can expect from Finetuner:
     <th>PRE-TRAINED</th>
     <th>FINE-TUNED</th>
     <th>DELTA</th>
-    <th>TIME</th>
   </tr>
 </thead>
 <tbody>
@@ -54,7 +53,6 @@ The following table demonstrates what you can expect from Finetuner:
     <td>0.835</td>
     <td>0.967</td>
     <td>:arrow_up_small: 15.8%</td>
-    <td rowspan="2">14 min</td>
   </tr>
   <tr>
     <td>Recall</td>
@@ -69,7 +67,6 @@ The following table demonstrates what you can expect from Finetuner:
     <td>0.102</td>
     <td>0.166</td>
     <td>:arrow_up_small: 62.7%</td>
-    <td rowspan="2">47 min</td>
   </tr>
   <tr>
     <td>Recall</td>
@@ -84,7 +81,6 @@ The following table demonstrates what you can expect from Finetuner:
     <td>0.192</td>
     <td>0.354</td>
     <td>:arrow_up_small: 84.4%</td>
-    <td rowspan="2">41 min</td>
   </tr>
   <tr>
     <td>Recall</td>


### PR DESCRIPTION
This PR removes `time` column in the readme table, which makes table shows correct and this column is useless since it has a linear relationship against training data size and device.