### PR TITLE
docs: replace content to uri if use image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Use `uri` to represent image content when creating training data. ([#484](https://github.com/jina-ai/finetuner/pull/484))
+
 
 ## [0.5.0] - 2022-06-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Use `uri` to represent image content when creating training data. ([#484](https://github.com/jina-ai/finetuner/pull/484))
+- Use `uri` to represent image content in documentation creating training data code snippet. ([#484](https://github.com/jina-ai/finetuner/pull/484))
 
 
 ## [0.5.0] - 2022-06-30

--- a/docs/walkthrough/create-training-data.md
+++ b/docs/walkthrough/create-training-data.md
@@ -28,11 +28,11 @@ from docarray import Document, DocumentArray
 
 train_da = DocumentArray([
     Document(
-        content='https://...skirt-1.png',
+        uri='https://...skirt-1.png',
         tags={'finetuner_label': 'skirt'},
     ),
     Document(
-        content='https://...t-shirt-1.png',
+        uri='https://...t-shirt-1.png',
         tags={'finetuner_label': 't-shirt'},
     ),
     ...,
@@ -52,7 +52,7 @@ train_da = DocumentArray([
                 tags={'finetuner_label': 'skirt-1'}
             ),
             Document(
-                content='https://...skirt-1.png',
+                uri='https://...skirt-1.png',
                 modality='image',
                 tags={'finetuner_label': 'skirt-1'}
             ),
@@ -66,7 +66,7 @@ train_da = DocumentArray([
                 tags={'finetuner_label': 'shirt-1'}
             ),
             Document(
-                content='https://...shirt-1.png',
+                uri='https://...shirt-1.png',
                 modality='image',
                 tags={'finetuner_label': 'shirt-1'}
             ),

--- a/docs/walkthrough/integrate-with-jina.md
+++ b/docs/walkthrough/integrate-with-jina.md
@@ -9,13 +9,18 @@ More specifically, the executor exposes an `/encode` endpoint that embeds [Docum
 
 Loading a tuned model is simple! You just need to provide a few parameters under the `uses_with` argument when adding the `FinetunerExecutor` to the [Flow]((https://docs.jina.ai/fundamentals/flow/)).
 
+## Via docker image
+
+## Via source code
+
 ````{tab} Python
 ```python
 from jina import Flow
 	
 f = Flow().add(
-    uses='jinahub+docker://FinetunerExecutor',
-    uses_with={'artifact': 'model_dir/tuned_model', 'batch_size': 16},
+    uses='jinahub://FinetunerExecutor/v0.9.1',  # note: use v0.9.1-gpu for GPU executor
+    uses_with={'artifact': '/your/model/path/artifact-name.zip'},
+    install_requirements=True,
 )
 ```
 ````
@@ -26,9 +31,9 @@ with:
   port: 51000
   protocol: grpc
 executors:
-  uses: jinahub+docker://FinetunerExecutor
+  uses: jinahub://FinetunerExecutor/v0.9.1  # note: use v0.9.1-gpu for GPU executor
   with:
-    artifact: 'model_dir/tuned_model'
+    artifact: '/your/model/path/artifact-name.zip'
     batch_size: 16
 ```
 ````
@@ -42,11 +47,6 @@ As you can see, it's super easy! We just provided the model path and the batch s
 
 In order to see what other options you can specify when initializing the executor, please go to the [`FinetunerExecutor`](https://hub.jina.ai/executor/13dzxycc) page and click on `Arguments` on the top-right side.
 
-```{admonition} FinetunerExecutor parameters
-:class: tip
-The only required argument is `artifact`. We provide default values for others.
-```
-
 
 ## Using `FinetunerExecutor`
 
@@ -57,8 +57,9 @@ from docarray import DocumentArray, Document
 from jina import Flow
 
 f = Flow().add(
-    uses='jinahub+docker://FinetunerExecutor',
-    uses_with={'artifact': 'model_dir/tuned_model', 'batch_size': 16},
+    uses='jinahub+docker://FinetunerExecutor/v0.9.1',  # note: use v0.9.1-gpu for GPU executor
+    uses_with={'artifact': '/your/model/path/artifact-name.zip', 'batch_size': 16},
+    volumes="/home/ubuntu/.cache:/root/.cache"
 )
 
 with f:

--- a/docs/walkthrough/integrate-with-jina.md
+++ b/docs/walkthrough/integrate-with-jina.md
@@ -34,19 +34,17 @@ executors:
   uses: jinahub://FinetunerExecutor/v0.9.1  # note: use v0.9.1-gpu for GPU executor
   with:
     artifact: '/your/model/path/artifact-name.zip'
-    batch_size: 16
 ```
 ````
-```{admonition} FinetunerExecutor via source code
-:class: tip
-You can also use the `FinetunerExecutor` via source code by specifying `jinahub://FinetunerExecutor` under the `uses` parameter.
-However, using docker images is recommended.
-```
 
 As you can see, it's super easy! We just provided the model path and the batch size.
 
 In order to see what other options you can specify when initializing the executor, please go to the [`FinetunerExecutor`](https://hub.jina.ai/executor/13dzxycc) page and click on `Arguments` on the top-right side.
 
+```{admonition} FinetunerExecutor parameters
+:class: tip
+The only required argument is `artifact`. We provide default values for others.
+```
 
 ## Using `FinetunerExecutor`
 
@@ -63,9 +61,9 @@ f = Flow().add(
 )
 
 with f:
-    returned_docs = f.post(on='/encode', inputs=DocumentArray([Document(text='hello')]))
+    encoded_docs = f.post(on='/encode', inputs=DocumentArray([Document(text='hello')]))
 
-for doc in returned_docs:
+for doc in encoded_docs:
     print(f'Text of the returned document: {doc.text}')
     print(f'Shape of the embedding: {doc.embedding.shape}')
 ```

--- a/docs/walkthrough/integrate-with-jina.md
+++ b/docs/walkthrough/integrate-with-jina.md
@@ -9,18 +9,13 @@ More specifically, the executor exposes an `/encode` endpoint that embeds [Docum
 
 Loading a tuned model is simple! You just need to provide a few parameters under the `uses_with` argument when adding the `FinetunerExecutor` to the [Flow]((https://docs.jina.ai/fundamentals/flow/)).
 
-## Via docker image
-
-## Via source code
-
 ````{tab} Python
 ```python
 from jina import Flow
 	
 f = Flow().add(
-    uses='jinahub://FinetunerExecutor/v0.9.1',  # note: use v0.9.1-gpu for GPU executor
-    uses_with={'artifact': '/your/model/path/artifact-name.zip'},
-    install_requirements=True,
+    uses='jinahub+docker://FinetunerExecutor',
+    uses_with={'artifact': 'model_dir/tuned_model', 'batch_size': 16},
 )
 ```
 ````
@@ -31,11 +26,17 @@ with:
   port: 51000
   protocol: grpc
 executors:
-  uses: jinahub://FinetunerExecutor/v0.9.1  # note: use v0.9.1-gpu for GPU executor
+  uses: jinahub+docker://FinetunerExecutor
   with:
-    artifact: '/your/model/path/artifact-name.zip'
+    artifact: 'model_dir/tuned_model'
+    batch_size: 16
 ```
 ````
+```{admonition} FinetunerExecutor via source code
+:class: tip
+You can also use the `FinetunerExecutor` via source code by specifying `jinahub://FinetunerExecutor` under the `uses` parameter.
+However, using docker images is recommended.
+```
 
 As you can see, it's super easy! We just provided the model path and the batch size.
 
@@ -46,6 +47,7 @@ In order to see what other options you can specify when initializing the executo
 The only required argument is `artifact`. We provide default values for others.
 ```
 
+
 ## Using `FinetunerExecutor`
 
 Here's a simple code snippet demonstrating the `FinetunerExecutor` usage in the Flow:
@@ -55,15 +57,14 @@ from docarray import DocumentArray, Document
 from jina import Flow
 
 f = Flow().add(
-    uses='jinahub+docker://FinetunerExecutor/v0.9.1',  # note: use v0.9.1-gpu for GPU executor
-    uses_with={'artifact': '/your/model/path/artifact-name.zip', 'batch_size': 16},
-    volumes="/home/ubuntu/.cache:/root/.cache"
+    uses='jinahub+docker://FinetunerExecutor',
+    uses_with={'artifact': 'model_dir/tuned_model', 'batch_size': 16},
 )
 
 with f:
-    encoded_docs = f.post(on='/encode', inputs=DocumentArray([Document(text='hello')]))
+    returned_docs = f.post(on='/encode', inputs=DocumentArray([Document(text='hello')]))
 
-for doc in encoded_docs:
+for doc in returned_docs:
     print(f'Text of the returned document: {doc.text}')
     print(f'Shape of the embedding: {doc.embedding.shape}')
 ```


### PR DESCRIPTION
<!--- PR Description here --->

This PR fixes `prepare training data` section, when user give an image uri, this image uri should use `uri` property rather than content.

---

- [ ] This PR references an open issue
- [x] I have added a line about this change to CHANGELOG