### PR TITLE
feat: add artifact id and token endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add artifact id and token interface to improve usability. ([#485](https://github.com/jina-ai/finetuner/pull/485))
+
 ### Removed
 
 ### Changed

--- a/finetuner/__init__.py
+++ b/finetuner/__init__.py
@@ -277,9 +277,8 @@ def delete_experiments() -> List[Experiment]:
 
 
 def get_token() -> str:
-    """Get user token.
+    """Get user token of jina ecosystem.
 
-    This is a helper function to get token and pull artifact from cloud storage.
     :return: user token as string object.
     """
     return ft.get_token()

--- a/finetuner/__init__.py
+++ b/finetuner/__init__.py
@@ -274,3 +274,12 @@ def delete_experiments() -> List[Experiment]:
     :return: List of deleted experiments.
     """
     return ft.delete_experiments()
+
+
+def get_token() -> str:
+    """Get user token.
+
+    This is a helper function to get token and pull artifact from cloud storage.
+    :return: user token as string object.
+    """
+    return ft.get_token()

--- a/finetuner/client/base.py
+++ b/finetuner/client/base.py
@@ -4,7 +4,6 @@ from typing import List, Optional, Union
 import requests
 
 import hubble
-from finetuner.client.exception import FinetunerServerError
 from finetuner.constants import (
     AUTHORIZATION,
     CHARSET,
@@ -15,6 +14,7 @@ from finetuner.constants import (
     TOKEN_PREFIX,
     UTF_8,
 )
+from finetuner.exception import FinetunerServerError
 
 
 class _BaseClient:

--- a/finetuner/client/client.py
+++ b/finetuner/client/client.py
@@ -3,7 +3,6 @@ from typing import List, Optional
 from finetuner.client.base import _BaseClient
 from finetuner.constants import (
     API_VERSION,
-    ARTIFACT_ID,
     CONFIG,
     CPUS,
     DELETE,
@@ -164,24 +163,6 @@ class FinetunerV1Client(_BaseClient):
             RUNS,
             run_name,
             LOGS,
-        )
-        return self._handle_request(url=url, method=GET)
-
-    def get_run_artifact_id(self, experiment_name: str, run_name: str) -> str:
-        """Get a run artifact id by its name and experiment.
-
-        :param experiment_name: The name of the experiment.
-        :param run_name: The name of the run.
-        :return: Run logs.
-        """
-        url = self._construct_url(
-            self._base_url,
-            API_VERSION,
-            EXPERIMENTS,
-            experiment_name,
-            RUNS,
-            run_name,
-            ARTIFACT_ID,
         )
         return self._handle_request(url=url, method=GET)
 

--- a/finetuner/client/client.py
+++ b/finetuner/client/client.py
@@ -3,6 +3,7 @@ from typing import List, Optional
 from finetuner.client.base import _BaseClient
 from finetuner.constants import (
     API_VERSION,
+    ARTIFACT_ID,
     CONFIG,
     CPUS,
     DELETE,
@@ -163,6 +164,24 @@ class FinetunerV1Client(_BaseClient):
             RUNS,
             run_name,
             LOGS,
+        )
+        return self._handle_request(url=url, method=GET)
+
+    def get_run_artifact_id(self, experiment_name: str, run_name: str) -> str:
+        """Get a run artifact id by its name and experiment.
+
+        :param experiment_name: The name of the experiment.
+        :param run_name: The name of the run.
+        :return: Run logs.
+        """
+        url = self._construct_url(
+            self._base_url,
+            API_VERSION,
+            EXPERIMENTS,
+            experiment_name,
+            RUNS,
+            run_name,
+            ARTIFACT_ID,
         )
         return self._handle_request(url=url, method=GET)
 

--- a/finetuner/constants.py
+++ b/finetuner/constants.py
@@ -32,7 +32,7 @@ EVAL_DATA = 'eval_data'
 ARTIFACTS_DIR = 'artifacts/'
 MODEL = 'model'
 MODEL_OPTIONS = 'model_options'
-MODEL_IDS = 'model_ids'
+ARTIFACT_ID = 'artifact_id'
 # Run status
 CREATED = 'CREATED'
 STARTED = 'STARTED'

--- a/finetuner/exception.py
+++ b/finetuner/exception.py
@@ -21,5 +21,5 @@ class RunFailedError(Exception):
     ...
 
 
-class UserNotLoginError(Exception):
+class UserNotLoggedInError(Exception):
     ...

--- a/finetuner/exception.py
+++ b/finetuner/exception.py
@@ -11,3 +11,15 @@ class FinetunerServerError(Exception):
 
     def __str__(self):
         return f'{self.message} ({self.code}): {self.details}'
+
+
+class RunInProgressError(Exception):
+    ...
+
+
+class RunFailedError(Exception):
+    ...
+
+
+class UserNotLoginError(Exception):
+    ...

--- a/finetuner/finetuner.py
+++ b/finetuner/finetuner.py
@@ -6,7 +6,7 @@ from docarray import DocumentArray
 import hubble
 from finetuner.client import FinetunerV1Client
 from finetuner.constants import CREATED_AT, DESCRIPTION, NAME, STATUS
-from finetuner.exception import UserNotLoginError
+from finetuner.exception import UserNotLoggedInError
 from finetuner.experiment import Experiment
 from finetuner.run import Run
 
@@ -240,5 +240,5 @@ class Finetuner:
 
     def get_token(self) -> str:
         if not self._client:
-            raise UserNotLoginError('Please call `login` before getting token.')
+            raise UserNotLoggedInError('Please call `login` before getting token.')
         return hubble.Auth.get_auth_token()

--- a/finetuner/finetuner.py
+++ b/finetuner/finetuner.py
@@ -236,3 +236,8 @@ class Finetuner:
             experiments = [self.get_experiment(name=experiment_name)]
         for experiment in experiments:
             experiment.delete_runs()
+
+    def get_token(self) -> str:
+        if not self._client:
+            raise ValueError('Client not initialized, please call `login` first.')
+        return hubble.Auth.get_auth_token()

--- a/finetuner/finetuner.py
+++ b/finetuner/finetuner.py
@@ -6,6 +6,7 @@ from docarray import DocumentArray
 import hubble
 from finetuner.client import FinetunerV1Client
 from finetuner.constants import CREATED_AT, DESCRIPTION, NAME, STATUS
+from finetuner.exception import UserNotLoginError
 from finetuner.experiment import Experiment
 from finetuner.run import Run
 
@@ -239,5 +240,5 @@ class Finetuner:
 
     def get_token(self) -> str:
         if not self._client:
-            raise ValueError('Client not initialized, please call `login` first.')
+            raise UserNotLoginError('Please call `login` before getting token.')
         return hubble.Auth.get_auth_token()

--- a/finetuner/hubble.py
+++ b/finetuner/hubble.py
@@ -64,22 +64,19 @@ def push_data(
 
 
 def download_artifact(
-    client, experiment_name: str, run_name: str, directory: str = ARTIFACTS_DIR
+    client, artifact_id: str, run_name: str, directory: str = ARTIFACTS_DIR
 ) -> str:
     """Download artifact from Hubble by its ID.
 
-    :param client: The Finetuner API client.
-    :param experiment_name: The name of the experiment.
-    :param run_name: The name of the run.
+    :param client: Hubble client instance.
+    :param artifact_id: The artifact id stored in the Hubble.
+    :param run_name: The name of the run as artifact name to store locally.
     :param directory: Directory where the artifact will be stored.
     :returns: A string that indicates the download path.
     """
     os.makedirs(directory, exist_ok=True)
 
-    run = client.get_run(experiment_name=experiment_name, run_name=run_name)
-
-    artifact_id = run['artifact_id']
-    path = os.path.join(directory, f'{run["name"]}.zip')
+    path = os.path.join(directory, f'{run_name}.zip')
 
     return client.hubble_client.download_artifact(
         id=artifact_id, f=path, show_progress=True

--- a/finetuner/run.py
+++ b/finetuner/run.py
@@ -71,3 +71,12 @@ class Run:
             run_name=self._name,
             directory=directory,
         )
+
+    def artifact_id(self):
+        """Get artifact id from the run."""
+        if self.status()[STATUS] != FINISHED:
+            raise Exception('The run needs to be finished in order to save the model.')
+
+        return self._client.get_run_artifact_id(
+            experiment_name=self._experiment_name, run_name=self._name
+        )

--- a/finetuner/run.py
+++ b/finetuner/run.py
@@ -75,7 +75,7 @@ class Run:
         status = self.status()[STATUS]
         if status in [CREATED, STARTED]:
             raise RunInProgressError(
-                'The run needs to be finished in order to save the model.'
+                'The run needs to be finished in order to save the artifact.'
             )
         if status == FAILED:
             raise RunFailedError(

--- a/finetuner/run.py
+++ b/finetuner/run.py
@@ -1,5 +1,5 @@
 from finetuner.client import FinetunerV1Client
-from finetuner.constants import ARTIFACTS_DIR, FINISHED, STATUS
+from finetuner.constants import ARTIFACT_ID, ARTIFACTS_DIR, FINISHED, STATUS
 from finetuner.hubble import download_artifact
 
 
@@ -29,6 +29,7 @@ class Run:
         self._config = config
         self._created_at = created_at
         self._description = description
+        self._run = self._get_run()
 
     @property
     def name(self) -> str:
@@ -37,6 +38,12 @@ class Run:
     @property
     def config(self) -> dict:
         return self._config
+
+    def _get_run(self) -> dict:
+        """Get Run object as dict."""
+        return self._client.get_run(
+            experiment_name=self._experiment_name, run_name=self._name
+        )
 
     def status(self) -> dict:
         """Run status.
@@ -67,7 +74,7 @@ class Run:
 
         return download_artifact(
             client=self._client,
-            experiment_name=self._experiment_name,
+            artifact_id=self._run[ARTIFACT_ID],
             run_name=self._name,
             directory=directory,
         )
@@ -77,6 +84,4 @@ class Run:
         if self.status()[STATUS] != FINISHED:
             raise Exception('The run needs to be finished in order to save the model.')
 
-        return self._client.get_run_artifact_id(
-            experiment_name=self._experiment_name, run_name=self._name
-        )
+        return self._run[ARTIFACT_ID]

--- a/finetuner/run.py
+++ b/finetuner/run.py
@@ -96,6 +96,7 @@ class Run:
             directory=directory,
         )
 
+    @property
     def artifact_id(self):
         """Get artifact id from the run.
 

--- a/tests/integration/test_runs.py
+++ b/tests/integration/test_runs.py
@@ -100,6 +100,12 @@ def test_create_run_and_save_model(finetuner_mocker, get_feature_data, tmp_path)
         status = run.status()[STATUS]
 
     assert status == FINISHED
+
+    artifact_id = run.artifact_id()
+    assert isinstance(artifact_id, str)
+    # the artifact id is a 24 character hex string defined in mongo db.
+    assert len(artifact_id) == 24
+
     run.save_artifact(directory=tmp_path / 'finetuned_model')
     assert os.path.exists(tmp_path / 'finetuned_model')
 

--- a/tests/integration/test_runs.py
+++ b/tests/integration/test_runs.py
@@ -101,7 +101,7 @@ def test_create_run_and_save_model(finetuner_mocker, get_feature_data, tmp_path)
 
     assert status == FINISHED
 
-    artifact_id = run.artifact_id()
+    artifact_id = run.artifact_id
     assert isinstance(artifact_id, str)
     # the artifact id is a 24 character hex string defined in mongo db.
     assert len(artifact_id) == 24


### PR DESCRIPTION
<!--- PR Description here --->

This PR allows user to get user token from Hubble, and get artifact id once fine-tuning is done. Usage:

```python
import finetuner

finetuner.login()
token = finetuner.get_token()

run = finetuner.get_run(run_name='something')
artifact_id = run.artifact_id
```

This allows user to directly pull artifact inside `FinetunerExecutor` using`token` and `artifact` as `artifact_id`.
This PR also did some minor refactoring on `download_artifact` and error handling.

A follow up PR will be created to update documentation including the usage of `FinetunerExecutor`.

---

- [ ] This PR references an open issue
- [x] I have added a line about this change to CHANGELOG