### PR TITLE
chore: bump hubble python sdk to 81

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Give more flexibility on dependency versions. ([#483](https://github.com/jina-ai/finetuner/pull/483))
 
+- Bump `jina-hubble-sdk` to 0.8.1. ([#488](https://github.com/jina-ai/finetuner/pull/488))
+
 ### Fixed
 
 - Use `uri` to represent image content in documentation creating training data code snippet. ([#484](https://github.com/jina-ai/finetuner/pull/484))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 docarray[common]>=0.13.19
-jina-hubble-sdk>=0.8.0
+jina-hubble-sdk>=0.8.1
 requests>=2.27.1
 rich>=12.4.4


### PR DESCRIPTION
<!--- PR Description here --->


To resolve the conflict between `jina-hubble-sdk` and jina in async functions: https://github.com/jina-ai/hubble-client-python/pull/49

---

- [ ] This PR references an open issue
- [x] I have added a line about this change to CHANGELOG