### PR TITLE
refactor: update readme and add connect function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `get_model` and `encode` method to encode docarray. ([#522](https://github.com/jina-ai/finetuner/pull/522))
 
+- Add connect function to package ([#532](https://github.com/jina-ai/finetuner/pull/532))
+
 ### Removed
 
 ### Changed
@@ -21,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve usability of `stream_logs`. ([#522](https://github.com/jina-ai/finetuner/pull/522))
 
 - Improve `describe_models` with open-clip models. ([#528](https://github.com/jina-ai/finetuner/pull/528))
+
+- Use stream logging in the README example ([#532](https://github.com/jina-ai/finetuner/pull/532))
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -152,8 +152,9 @@ import finetuner
 finetuner.login()
 
 run = finetuner.get_run('resnet50-tll-run')
-print(run.status())
-print(run.logs())
+
+for msg in run.stream_logs():
+    print(msg)
 
 run.save_artifact('resnet-tll')
 ```
@@ -173,10 +174,9 @@ Finally, you can use the model to encode images:
 import finetuner
 from docarray import Document, DocumentArray
 
-model = finetuner.get_model('resnet-tll')
-
 da = DocumentArray([Document(uri='~/Pictures/your_img.png')])
 
+model = finetuner.get_model('resnet-tll')
 finetuner.encode(model=model, data=da)
 
 da.summary()

--- a/finetuner/__init__.py
+++ b/finetuner/__init__.py
@@ -34,6 +34,10 @@ def login():
     ft.login()
 
 
+def connect():
+    ft.connect()
+
+
 def list_callbacks() -> Dict[str, callback.CallbackStubType]:
     """List available callbacks."""
     return {


### PR DESCRIPTION
Minor changes to readme and __init__
---

This adds the readme changes from https://github.com/jina-ai/finetuner/pull/530 and make `connect` available directly from the finetuner module

- [ ] This PR references an open issue
- [x] I have added a line about this change to CHANGELOG