### PR TITLE
docs: update metric tables and hyperparameters for clip finetuning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Change CLIP finetuning example in the documentation ([#569](https://github.com/jina-ai/finetuner/pull/569))
+
 ### Fixed
 
 ### Docs

--- a/README.md
+++ b/README.md
@@ -79,21 +79,21 @@ With Finetuner, one can easily uplift pre-trained models to be more performant a
     <td rowspan="2">CLIP</td>
     <td rowspan="2"><a href="https://mmlab.ie.cuhk.edu.hk/projects/DeepFashion.html">Deep Fashion</a> text-to-image search</td>
     <td>mRR</td>
-    <td>0.289</td>
-    <td>0.488</td>
-    <td>:arrow_up_small: 69.9%</td>
+    <td>0.575</td>
+    <td>0.676</td>
+    <td>:arrow_up_small: 17.4%</td>
   </tr>
   <tr>
     <td>Recall</td>
-    <td>0.109</td>
-    <td>0.346</td>
-    <td>:arrow_up_small: 217.0%</td>
+    <td>0.473</td>
+    <td>0.564</td>
+    <td>:arrow_up_small: 19.2%</td>
   </tr>
 
 </tbody>
 </table>
 
-<sub><sup><a id="example-setup">[*]</a> All metrics evaluation on k@20, trained 5 epochs using Adam optimizer with learning rate of 1e-5.</sup></sub>
+<sub><sup>All metrics are evaluated on k@20 after training for 5 epochs using Adam optimizer with learning rates of 1e-7 for CLIP and 1e-5 for the other models.</sup></sub>
 
 <!-- start install-instruction -->
 

--- a/docs/tasks/text-to-image.md
+++ b/docs/tasks/text-to-image.md
@@ -40,10 +40,10 @@ import finetuner
 run = finetuner.fit(
     model='openai/clip-vit-base-patch32',
     run_name='clip-fashion',
-    train_data='clip-fashion-train-data',
-    eval_data='clip-fashion-eval-data',
+    train_data='fashion-eval-train-clip',
+    eval_data='fashion-eval-data-clip',
     epochs=5,
-    learning_rate= 1e-5,
+    learning_rate= 1e-7,
     loss='CLIPLoss',
     cpu=False,
 )
@@ -104,16 +104,16 @@ We have done the evaulation for you in the table below.
 ```
 
 |                   | Before Finetuning | After Finetuning |
-|:------------------|----------:|---------:|
-| average_precision | 0.253423  | 0.415924 |
-| dcg_at_k          | 0.902417  | 2.14489  |
-| f1_score_at_k     | 0.0831918 | 0.241773 |
-| hit_at_k          | 0.611976  | 0.856287 |
-| ndcg_at_k         | 0.350172  | 0.539948 |
-| precision_at_k    | 0.0994012 | 0.256587 |
-| r_precision       | 0.231756  | 0.35847  |
-| recall_at_k       | 0.108982  | 0.346108 |
-| reciprocal_rank   | 0.288791  | 0.487505 |
+|:------------------|---------:|---------:|
+| average_precision | 0.47219  | 0.532773 |
+| dcg_at_k          | 2.25565  | 2.70725  |
+| f1_score_at_k     | 0.296816 | 0.353499 |
+| hit_at_k          | 0.94028  | 0.942821 |
+| ndcg_at_k         | 0.613387 | 0.673644 |
+| precision_at_k    | 0.240407 | 0.285324 |
+| r_precision       | 0.364697 | 0.409577 |
+| recall_at_k       | 0.472681 | 0.564168 |
+| reciprocal_rank   | 0.575481 | 0.67571  |
 
 ## Saving
 


### PR DESCRIPTION
The evaluation metric scores for finetuning clip where not correct. Now, I used a bigger portion of the fashion captioning dataset for finetuning, slightly changed the hyperparmeter to values which work better and update the evaluation metric scores

---

- [ ] This PR references an open issue
- [x] I have added a line about this change to CHANGELOG