### PR TITLE
chore: bump flake8 version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ if __name__ == '__main__':
             ],
             'test': [
                 'black==22.3.0',
-                'flake8==4.0.1',
+                'flake8==5.0.4',
                 'isort==5.10.1',
                 'pytest==7.0.0',
                 'pytest-cov==3.0.0',


### PR DESCRIPTION
Bumps version of flake8 to fix the dependency issue which causes the CI to fail
---

- [ ] This PR references an open issue
- [ ] I have added a line about this change to CHANGELOG