### PR TITLE
docs: add wise-ft to clip finetuning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Support advanced CLIP fine-tuning with WiSE-FT ([#571](https://github.com/jina-ai/finetuner/pull/571))
+
 ### Removed
 
 ### Changed

--- a/docs/tasks/text-to-image.md
+++ b/docs/tasks/text-to-image.md
@@ -163,16 +163,16 @@ In case you set `to_onnx=True` when calling `finetuner.fit` function,
 please use `model = finetuner.get_model('/path/to/YOUR-MODEL.zip', is_onnx=True)`
 ```
 
-## Advanced: Apply Wise-ft 
+## Advanced: WiSE-FT 
 
-Wise-ft, proposed by Mitchell et al. in [Robust fine-tuning of zero-shot models](https://arxiv.org/abs/2109.01903),
-has been proven to be an effective way for fine-tuning models with strong zero-shot capability,
+WiSE-FT, proposed by Mitchell et al. in [Robust fine-tuning of zero-shot models](https://arxiv.org/abs/2109.01903),
+has been proven to be an effective way for fine-tuning models with a strong zero-shot capability,
 such as CLIP.
 As was introduced in the paper:
 
 > Large pre-trained models such as CLIP or ALIGN offer consistent accuracy across a range of data distributions when performing zero-shot inference (i.e., without fine-tuning on a specific dataset). Although existing fine-tuning methods substantially improve accuracy on a given target distribution, they often reduce robustness to distribution shifts. We address this tension by introducing a simple and effective method for improving robustness while fine-tuning: ensembling the weights of the zero-shot and fine-tuned models (WiSE-FT).
 
-Finetuner allows you to apply wise-ft on your run,
+Finetuner allows you to apply WiSE-FT easily,
 all you need to do is to pass a coefficient to the `model_options`, such as:
 
 ```diff
@@ -192,6 +192,5 @@ The value you set to `wise_ft` should be greater equal than 0 and less equal tha
 + if `wise_ft` is 1, the pre-trained weights will not be utilized.
 
 
-Check out [clip-as-service](https://clip-as-service.jina.ai/user-guides/finetuner/?highlight=finetuner#fine-tune-models) to learn how to plug-in a finetuned CLIP model to our CLIP specific service.
-
 That's it! If you want to integrate the fine-tuned model into your Jina Flow, please check out {ref}`integrated with the Jina ecosystem <integrate-with-jina>`.
+Check out [clip-as-service](https://clip-as-service.jina.ai/user-guides/finetuner/?highlight=finetuner#fine-tune-models) to learn how to plug-in a fine-tuned CLIP model to our CLIP specific service.

--- a/docs/tasks/text-to-image.md
+++ b/docs/tasks/text-to-image.md
@@ -174,11 +174,11 @@ As was introduced in the paper:
 > Large pre-trained models such as CLIP or ALIGN offer consistent accuracy across a range of data distributions when performing zero-shot inference (i.e., without fine-tuning on a specific dataset). Although existing fine-tuning methods substantially improve accuracy on a given target distribution, they often reduce robustness to distribution shifts. We address this tension by introducing a simple and effective method for improving robustness while fine-tuning: ensembling the weights of the zero-shot and fine-tuned models (WiSE-FT).
 
 Finetuner allows you to apply WiSE-FT easily,
-all you need to do is use `WiSEFTCallback`.
+all you need to do is use the `WiSEFTCallback`.
 Finetuner will trigger the callback when fine-tuning job finished and merge the weights between the pre-trained model and the fine-tuned model:
 
 ```diff
-import finetuner.callbakcs import WiSEFTCallback
+from finetuner.callbakcs import WiSEFTCallback
 
 run = finetuner.fit(
     model='ViT-B-32#openai',
@@ -189,11 +189,11 @@ run = finetuner.fit(
 )
 ```
 
-The value you set to `wise_ft` should be greater equal than 0 and less equal than 1:
+The value you set to `alpha` should be greater equal than 0 and less equal than 1:
 
-+ if `wise_ft` is a float between 0 and 1, we merge the weights between the pre-trained model and the fine-tuned model.
-+ if `wise_ft` is 0, the fine-tuned model is identical to the pre-trained model.
-+ if `wise_ft` is 1, the pre-trained weights will not be utilized.
++ if `alpha` is a float between 0 and 1, we merge the weights between the pre-trained model and the fine-tuned model.
++ if `alpha` is 0, the fine-tuned model is identical to the pre-trained model.
++ if `alpha` is 1, the pre-trained weights will not be utilized.
 
 
 That's it! If you want to integrate the fine-tuned model into your Jina Flow, please check out {ref}`integrated with the Jina ecosystem <integrate-with-jina>`.

--- a/docs/tasks/text-to-image.md
+++ b/docs/tasks/text-to-image.md
@@ -180,8 +180,8 @@ run = finetuner.fit(
     model='ViT-B-32#openai',
     ...,
     loss = 'CLIPLoss',
--   model_options={},
-+   model_options={'wise_ft': 0.4},
+-   callbacks=[],
++   callbacks=[WiseFtCallback(alpha=0.4)],
 )
 ```
 

--- a/docs/tasks/text-to-image.md
+++ b/docs/tasks/text-to-image.md
@@ -187,8 +187,8 @@ run = finetuner.fit(
 
 The value you set to `wise_ft` should be greater equal than 0 and less equal than 1:
 
-+ if `wise_ft` is a float between 0 and 1, we merge weights between pre-trained and fine-tuned model.
-+ if `wise_ft` is 0, the fine-tuned model will be identical to pre-trained model.
++ if `wise_ft` is a float between 0 and 1, we merge the weights between the pre-trained model and the fine-tuned model.
++ if `wise_ft` is 0, the fine-tuned model is identical to the pre-trained model.
 + if `wise_ft` is 1, the pre-trained weights will not be utilized.
 
 

--- a/docs/tasks/text-to-image.md
+++ b/docs/tasks/text-to-image.md
@@ -174,18 +174,18 @@ As was introduced in the paper:
 > Large pre-trained models such as CLIP or ALIGN offer consistent accuracy across a range of data distributions when performing zero-shot inference (i.e., without fine-tuning on a specific dataset). Although existing fine-tuning methods substantially improve accuracy on a given target distribution, they often reduce robustness to distribution shifts. We address this tension by introducing a simple and effective method for improving robustness while fine-tuning: ensembling the weights of the zero-shot and fine-tuned models (WiSE-FT).
 
 Finetuner allows you to apply WiSE-FT easily,
-all you need to do is to pass a coefficient to the `model_options`, such as:
+all you need to do is use `WiSEFTCallback`.
+Finetuner will trigger the callback when fine-tuning job finished and merge the weights between the pre-trained model and the fine-tuned model:
 
 ```diff
 import finetuner.callbakcs import WiSEFTCallback
 
 run = finetuner.fit(
-     model='ViT-B-32#openai',
-     ...,
-     loss='CLIPLoss',
--    callbacks=[],
-+    callbacks=[WiSEFTCallback(alpha=0.5)],
-     ...
+    model='ViT-B-32#openai',
+    ...,
+    loss='CLIPLoss',
+-   callbacks=[],
++   callbacks=[WiSEFTCallback(alpha=0.5)],
 )
 ```
 

--- a/docs/tasks/text-to-image.md
+++ b/docs/tasks/text-to-image.md
@@ -163,6 +163,35 @@ In case you set `to_onnx=True` when calling `finetuner.fit` function,
 please use `model = finetuner.get_model('/path/to/YOUR-MODEL.zip', is_onnx=True)`
 ```
 
+## Advanced: Apply Wise-ft 
+
+Wise-ft, proposed by Mitchell et al. in [Robust fine-tuning of zero-shot models](https://arxiv.org/abs/2109.01903),
+has been proven to be an effective way for fine-tuning models with strong zero-shot capability,
+such as CLIP.
+As was introduced in the paper:
+
+> Large pre-trained models such as CLIP or ALIGN offer consistent accuracy across a range of data distributions when performing zero-shot inference (i.e., without fine-tuning on a specific dataset). Although existing fine-tuning methods substantially improve accuracy on a given target distribution, they often reduce robustness to distribution shifts. We address this tension by introducing a simple and effective method for improving robustness while fine-tuning: ensembling the weights of the zero-shot and fine-tuned models (WiSE-FT).
+
+Finetuner allows you to apply wise-ft on your run,
+all you need to do is to pass a coefficient to the `model_options`, such as:
+
+```diff
+run = finetuner.fit(
+    model='ViT-B-32#openai',
+    ...,
+    loss = 'CLIPLoss',
+-   model_options={},
++   model_options={'wise_ft': 0.4},
+)
+```
+
+The value you set to `wise_ft` should be greater equal than 0 and less equal than 1:
+
++ if `wise_ft` is a float between 0 and 1, we merge weights between pre-trained and fine-tuned model.
++ if `wise_ft` is 0, the fine-tuned model will be identical to pre-trained model.
++ if `wise_ft` is 1, the pre-trained weights will not be utilized.
+
+
 Check out [clip-as-service](https://clip-as-service.jina.ai/user-guides/finetuner/?highlight=finetuner#fine-tune-models) to learn how to plug-in a finetuned CLIP model to our CLIP specific service.
 
 That's it! If you want to integrate the fine-tuned model into your Jina Flow, please check out {ref}`integrated with the Jina ecosystem <integrate-with-jina>`.

--- a/docs/walkthrough/using-callbacks.md
+++ b/docs/walkthrough/using-callbacks.md
@@ -134,4 +134,9 @@ WiSE-FT, proposed by Mitchell et al. in [Robust fine-tuning of zero-shot models]
 has been proven to be an effective way for fine-tuning models with a strong zero-shot capability,
 such as CLIP.
 
-Please refer to {ref}`Apply WiSE-FT <wise-ft>`
+Please refer to {ref}`Apply WiSE-FT <wise-ft>` in the CLIP fine-tuning example.
+
+```{warning}
+It is recommended to use WiSTFTCallback when fine-tuning CLIP.
+We can not ensure it works for other category of models, such as ResNet or Bert.
+```

--- a/docs/walkthrough/using-callbacks.md
+++ b/docs/walkthrough/using-callbacks.md
@@ -128,7 +128,7 @@ The early stopping callback triggers at the end of training and evaluation batch
 - `baseline`: an optional parameter that is used to compare the model's score against instead of the best previous model when checking for improvement. This baseline does not get changed over the course of a run.
 
 
-## WiSTFTCallback
+## WiSEFTCallback
 
 WiSE-FT, proposed by Mitchell et al. in [Robust fine-tuning of zero-shot models](https://arxiv.org/abs/2109.01903),
 has been proven to be an effective way for fine-tuning models with a strong zero-shot capability,
@@ -137,6 +137,6 @@ such as CLIP.
 Please refer to {ref}`Apply WiSE-FT <wise-ft>` in the CLIP fine-tuning example.
 
 ```{warning}
-It is recommended to use WiSTFTCallback when fine-tuning CLIP.
+It is recommended to use WiSEFTCallback when fine-tuning CLIP.
 We can not ensure it works for other category of models, such as ResNet or Bert.
 ```


### PR DESCRIPTION
<!--- PR Description here --->

In this PR, we start to support WiSE-FT fine-tuning for models with a strong zero-shot capability, to merge weights between pre-trained model and zero-shot model. Currently all CLIP-family models are supported. Functionality has been implemented inside core. To make use of it:

```diff
import finetuner

run = finetuner.fit(
     model='ViT-B-32#openai',
     ...,
     loss = 'CLIPLoss',
-    callbacks=[],
+    callbacks=[WiSEFTCallback(alpha=0.4)],
)
```

Review documentation change [here](https://ft-docs-wise-ft--jina-docs.netlify.app/docs-wise-ft/tasks/text-to-image/#advanced-wise-ft)

---

- [x] This PR references an open issue
- [x] I have added a line about this change to CHANGELOG