### PR TITLE
refactor: unify cpu gpu into device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Use `device` parameter to replace `cpu` to align with docarray  ([#577](https://github.com/jina-ai/finetuner/pull/577))
+
 ### Fixed
 
 ### Docs

--- a/docs/tasks/image-to-image.md
+++ b/docs/tasks/image-to-image.md
@@ -57,7 +57,7 @@ run = finetuner.fit(
     batch_size=128,
     epochs=5,
     learning_rate=1e-5,
-    cpu=False,
+    device='cuda',
     callbacks=[
         EvaluationCallback(
             query_data='tll-test-query-da',

--- a/docs/tasks/text-to-image.md
+++ b/docs/tasks/text-to-image.md
@@ -11,7 +11,7 @@ For each product the dataset contains a title and images of multiple variants of
 
 ## Data
 Our journey starts locally. We have to {ref}`prepare the data and push it to the cloud <create-training-data>` and Finetuner will be able to get the dataset by its name. For this example,
-we already prepared the data, and we'll provide the names of training and evaluation data (`clip-fashion-train-data` and `clip-fashion-eval-data`) directly to Finetuner.
+we already prepared the data, and we'll provide the names of training and evaluation data (`fashion-eval-train-clip` and `fashion-eval-data-clip`) directly to Finetuner.
 
 ```{admonition} 
 :class: tip

--- a/docs/tasks/text-to-image.md
+++ b/docs/tasks/text-to-image.md
@@ -45,7 +45,7 @@ run = finetuner.fit(
     epochs=5,
     learning_rate= 1e-7,
     loss='CLIPLoss',
-    cpu=False,
+    device='cuda',
 )
 ```
 Let's understand what this piece of code does:

--- a/docs/tasks/text-to-text.md
+++ b/docs/tasks/text-to-text.md
@@ -115,7 +115,7 @@ run = finetuner.fit(
     learning_rate = 1e-5,
     epochs=3,
     batch_size=128,
-    cpu=False,
+    device='cuda',
     callbacks=[
         EvaluationCallback(
             query_data='quora_query_dev.da',

--- a/docs/walkthrough/run-job.md
+++ b/docs/walkthrough/run-job.md
@@ -71,7 +71,7 @@ run = finetuner.fit(
     scheduler_step='batch',
     freeze=False, # If applied will freeze the embedding model, only train the MLP.
     output_dim=512, # Attach a MLP on top of embedding model.
-    cpu=False,
+    device='cuda',
     num_workers=4,
     to_onnx=False,  # If set, please pass `is_onnx` when making inference.
 )

--- a/docs/walkthrough/using-callbacks.md
+++ b/docs/walkthrough/using-callbacks.md
@@ -108,7 +108,7 @@ run = finetuner.fit(
     epochs=10,
     learning_rate= 1e-5,
     loss='CLIPLoss',
-    cpu=False,
+    device='cuda',
     callbacks= [
         callback.EarlyStopping(
             monitor = "train_loss",

--- a/finetuner/__init__.py
+++ b/finetuner/__init__.py
@@ -110,8 +110,8 @@ def fit(
     scheduler_step: str = 'batch',
     freeze: bool = False,
     output_dim: Optional[int] = None,
-    cpu: bool = True,
-    device: str = 'cpu',
+    cpu: bool = False,
+    device: str = 'cuda',
     num_workers: int = 4,
     to_onnx: bool = False,
 ) -> Run:

--- a/finetuner/__init__.py
+++ b/finetuner/__init__.py
@@ -168,6 +168,7 @@ def fit(
     :param output_dim: The expected output dimension as `int`.
         If set, will attach a projection head.
     :param cpu: Whether to use the CPU. If set to `False` a GPU will be used.
+        Will be deprecated from 0.7.0.
     :param device: Whether to use the CPU, if set to `cuda`, a Nvidia GPU will be used.
         otherwise use `cpu` to run a cpu job.
     :param num_workers: Number of CPU workers. If `cpu: False` this is the number of
@@ -350,7 +351,7 @@ def get_model(
     if device == 'cuda' and is_onnx:
         warnings.warn(
             message='You are using cuda device for ONNX inference, please consider'
-            'call `pip install onnxruntime-gpu` to speed up inference.',
+            'calling `pip install onnxruntime-gpu` to speed up inference.',
             category=RuntimeWarning,
         )
     if is_onnx:

--- a/finetuner/__init__.py
+++ b/finetuner/__init__.py
@@ -110,7 +110,7 @@ def fit(
     scheduler_step: str = 'batch',
     freeze: bool = False,
     output_dim: Optional[int] = None,
-    cpu: bool = False,
+    cpu: bool = True,
     device: str = 'cuda',
     num_workers: int = 4,
     to_onnx: bool = False,

--- a/finetuner/__init__.py
+++ b/finetuner/__init__.py
@@ -107,6 +107,7 @@ def fit(
     freeze: bool = False,
     output_dim: Optional[int] = None,
     cpu: bool = True,
+    device: str = 'cpu',
     num_workers: int = 4,
     to_onnx: bool = False,
 ) -> Run:
@@ -163,6 +164,7 @@ def fit(
     :param output_dim: The expected output dimension as `int`.
         If set, will attach a projection head.
     :param cpu: Whether to use the CPU. If set to `False` a GPU will be used.
+    :param device: Whether to use the CPU, if set to `cuda`, a Nvidia GPU will be used.
     :param num_workers: Number of CPU workers. If `cpu: False` this is the number of
         workers used by the dataloader.
     :param to_onnx: If the model is an onnx model or not. If you call the `fit` function
@@ -189,6 +191,7 @@ def fit(
         freeze=freeze,
         output_dim=output_dim,
         cpu=cpu,
+        device=device,
         num_workers=num_workers,
         to_onnx=to_onnx,
     )
@@ -300,7 +303,7 @@ def get_model(
     token: Optional[str] = None,
     batch_size: int = 32,
     select_model: Optional[str] = None,
-    gpu: bool = False,
+    device: str = 'cpu',
     logging_level: str = 'WARNING',
     is_onnx: bool = False,
 ):
@@ -319,7 +322,7 @@ def get_model(
     :param select_model: Finetuner run artifacts might contain multiple models. In
         such cases you can select which model to deploy using this argument. For CLIP
         fine-tuning, you can choose either `clip-vision` or `clip-text`.
-    :param gpu: if specified to True, use cuda device for inference.
+    :param device: Whether to use the CPU, if set to `cuda`, a Nvidia GPU will be used.
     :param logging_level: The executor logging level. See
         https://docs.python.org/3/library/logging.html#logging-levels for available
         options.
@@ -334,7 +337,7 @@ def get_model(
         TorchInferenceEngine,
     )
 
-    if gpu:
+    if device == 'cuda' and is_onnx:
         warnings.warn(
             message='You are using cuda device for ONNX inference, please consider'
             'call `pip install onnxruntime-gpu` to speed up inference.',
@@ -346,7 +349,7 @@ def get_model(
             token=token,
             batch_size=batch_size,
             select_model=select_model,
-            device='cuda' if gpu else 'cpu',
+            device=device,
             logging_level=logging_level,
         )
     else:
@@ -355,7 +358,7 @@ def get_model(
             token=token,
             batch_size=batch_size,
             select_model=select_model,
-            device='cuda' if gpu else 'cpu',
+            device=device,
             logging_level=logging_level,
         )
     return inference_engine

--- a/finetuner/__init__.py
+++ b/finetuner/__init__.py
@@ -169,10 +169,15 @@ def fit(
         If set, will attach a projection head.
     :param cpu: Whether to use the CPU. If set to `False` a GPU will be used.
     :param device: Whether to use the CPU, if set to `cuda`, a Nvidia GPU will be used.
+        otherwise use `cpu` to run a cpu job.
     :param num_workers: Number of CPU workers. If `cpu: False` this is the number of
         workers used by the dataloader.
     :param to_onnx: If the model is an onnx model or not. If you call the `fit` function
         with `to_onnx=True`, please set this parameter as `True`.
+
+    .. note::
+       Unless necessary, please stick with `device="cuda"`, `cpu` training could be
+       extremely slow and inefficient.
     """
     return ft.create_run(
         model=model,
@@ -327,6 +332,7 @@ def get_model(
         such cases you can select which model to deploy using this argument. For CLIP
         fine-tuning, you can choose either `clip-vision` or `clip-text`.
     :param device: Whether to use the CPU, if set to `cuda`, a Nvidia GPU will be used.
+        otherwise use `cpu` to run a cpu job.
     :param logging_level: The executor logging level. See
         https://docs.python.org/3/library/logging.html#logging-levels for available
         options.

--- a/finetuner/experiment.py
+++ b/finetuner/experiment.py
@@ -167,7 +167,7 @@ class Experiment:
             **kwargs,
         )
 
-        device = kwargs.get(DEVICE, 'cpu')
+        device = kwargs.get(DEVICE, 'cuda')
         if device == 'cpu' and not kwargs.get(CPU, True):
             device = 'gpu'
             warnings.warn(

--- a/finetuner/experiment.py
+++ b/finetuner/experiment.py
@@ -168,18 +168,16 @@ class Experiment:
         )
 
         device = kwargs.get(DEVICE, 'cuda')
-        if device == 'cuda' and kwargs.get(CPU, True):
-            device = 'gpu'
-            warnings.warn(
-                message='Parameter `cpu=True` will be deprecated from Finetuner 0.7.0,'
-                'please use `device="cpu" or `device="cuda" instead.`',
-                category=DeprecationWarning,
-            )
         if device == 'cuda':
-            device = 'gpu'  # Map cuda to gpu to align with api
+            device = 'gpu'
+            if kwargs.get(CPU, True):
+                warnings.warn(
+                    message='Parameter `cpu` will be deprecated from Finetuner 0.7.0,'
+                    'please use `device="cpu" or `device="cuda" instead.`',
+                    category=DeprecationWarning,
+                )
 
         num_workers = kwargs.get(NUM_WORKERS, 4)
-
         run_info = self._client.create_run(
             run_name=run_name,
             experiment_name=self._name,

--- a/finetuner/experiment.py
+++ b/finetuner/experiment.py
@@ -168,7 +168,7 @@ class Experiment:
         )
 
         device = kwargs.get(DEVICE, 'cpu')
-        if device == 'cpu' and not kwargs.get(CPU):
+        if device == 'cpu' and not kwargs.get(CPU, True):
             device = 'gpu'
             warnings.warn(
                 message='Parameter `cpu=True` will be deprecated from Finetuner 0.7.0,'
@@ -176,7 +176,7 @@ class Experiment:
                 category=DeprecationWarning,
             )
         if device == 'cuda':
-            device = 'gpu'
+            device = 'gpu'  # Map cuda to gpu to align with core
 
         num_workers = kwargs.get(NUM_WORKERS, 4)
 

--- a/finetuner/experiment.py
+++ b/finetuner/experiment.py
@@ -171,8 +171,8 @@ class Experiment:
         if device == 'cpu' and not kwargs.get(CPU):
             device = 'gpu'
             warnings.warn(
-                message='`cpu` will be deprecated from 0.7.0, please use'
-                '`device="cpu" or `device="cuda" instead.`',
+                message='Parameter `cpu=True` will be deprecated from Finetuner 0.7.0,'
+                'please use `device="cpu" or `device="cuda" instead.`',
                 category=DeprecationWarning,
             )
         if device == 'cuda':

--- a/finetuner/experiment.py
+++ b/finetuner/experiment.py
@@ -1,3 +1,4 @@
+import warnings
 from dataclasses import fields
 from typing import Any, Dict, List, Optional, Union
 
@@ -13,6 +14,7 @@ from finetuner.constants import (
     CREATED_AT,
     DATA,
     DESCRIPTION,
+    DEVICE,
     EPOCHS,
     EVAL_DATA,
     EXPERIMENT_NAME,
@@ -165,14 +167,24 @@ class Experiment:
             **kwargs,
         )
 
-        cpu = kwargs.get(CPU, True)
+        device = kwargs.get(DEVICE, 'cpu')
+        if device == 'cpu' and not kwargs.get(CPU):
+            device = 'gpu'
+            warnings.warn(
+                message='`cpu` will be deprecated from 0.7.0, please use'
+                '`device="cpu" or `device="cuda" instead.`',
+                category=DeprecationWarning,
+            )
+        if device == 'cuda':
+            device = 'gpu'
+
         num_workers = kwargs.get(NUM_WORKERS, 4)
 
         run_info = self._client.create_run(
             run_name=run_name,
             experiment_name=self._name,
             run_config=config,
-            device='cpu' if cpu else 'gpu',
+            device=device,
             cpus=num_workers,
             gpus=1,
         )

--- a/finetuner/experiment.py
+++ b/finetuner/experiment.py
@@ -168,7 +168,7 @@ class Experiment:
         )
 
         device = kwargs.get(DEVICE, 'cuda')
-        if device == 'cpu' and not kwargs.get(CPU, True):
+        if device == 'cuda' and kwargs.get(CPU, True):
             device = 'gpu'
             warnings.warn(
                 message='Parameter `cpu=True` will be deprecated from Finetuner 0.7.0,'
@@ -176,7 +176,7 @@ class Experiment:
                 category=DeprecationWarning,
             )
         if device == 'cuda':
-            device = 'gpu'  # Map cuda to gpu to align with core
+            device = 'gpu'  # Map cuda to gpu to align with api
 
         num_workers = kwargs.get(NUM_WORKERS, 4)
 

--- a/finetuner/finetuner.py
+++ b/finetuner/finetuner.py
@@ -170,7 +170,7 @@ class Finetuner:
         scheduler_step: str = 'batch',
         freeze: bool = False,
         output_dim: Optional[int] = None,
-        cpu: bool = False,
+        cpu: bool = True,
         device: str = 'cuda',
         num_workers: int = 4,
         to_onnx: bool = False,

--- a/finetuner/finetuner.py
+++ b/finetuner/finetuner.py
@@ -170,8 +170,8 @@ class Finetuner:
         scheduler_step: str = 'batch',
         freeze: bool = False,
         output_dim: Optional[int] = None,
-        cpu: bool = True,
-        device: str = 'cpu',
+        cpu: bool = False,
+        device: str = 'cuda',
         num_workers: int = 4,
         to_onnx: bool = False,
     ) -> Run:

--- a/finetuner/finetuner.py
+++ b/finetuner/finetuner.py
@@ -159,6 +159,7 @@ class Finetuner:
         freeze: bool = False,
         output_dim: Optional[int] = None,
         cpu: bool = True,
+        device: str = 'cpu',
         num_workers: int = 4,
         to_onnx: bool = False,
     ) -> Run:
@@ -193,6 +194,7 @@ class Finetuner:
             freeze=freeze,
             output_dim=output_dim,
             cpu=cpu,
+            device=device,
             num_workers=num_workers,
             to_onnx=to_onnx,
         )

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ if __name__ == '__main__':
         install_requires=[
             'docarray[common]>=0.13.31',
             'finetuner-stubs==0.10.4',
-            'jina-hubble-sdk>=0.19.0',
+            'jina-hubble-sdk==0.21.0',
         ],
         extras_require={
             'full': [

--- a/tests/unit/test_experiment.py
+++ b/tests/unit/test_experiment.py
@@ -147,6 +147,8 @@ def test_create_run_config():
         multi_modal=False,
         image_modality=None,
         text_modality=None,
+        cpu=False,
+        device='cuda',
         wandb_api_key=None,
     )
     assert config == expected_config

--- a/tests/unit/test_experiment.py
+++ b/tests/unit/test_experiment.py
@@ -147,7 +147,6 @@ def test_create_run_config():
         multi_modal=False,
         image_modality=None,
         text_modality=None,
-        cpu=False,
         wandb_api_key=None,
     )
     assert config == expected_config


### PR DESCRIPTION
<!--- PR Description here --->

Resolve inconsistency between `fit` end `get_model`, in `fit` we use `cpu`, in `get_model` we use `gpu`. Better to align with Docarray `device='cpu'` or `device='cuda'`.

This will not be a breaking change for internal users. 

This will be a breaking change for ppl install `finetuner-full`  when calling `get_model`.

A follow up ticket has been created to remove `cpu` in `0.7.0` #578 

```diff
# training time
run = finetuner.fit(
    ...,
-   cpu=False,  # cpu is still supported, no breaking change, we sunset `cpu` after 0.7
+   device='cuda', # note, now `cuda` is the default device.
)

# inference time
inference_engine = finetuner.get_model(
     ...,
-    gpu=True, 
+    device='cuda',  # note, `cpu` is the default device unless user specify `cuda`.
)
```

---

- [ ] This PR references an open issue
- [x] I have added a line about this change to CHANGELOG