### PR TITLE
docs: update names of open clip models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update the open clip model names in the table of the backbones ([#580](https://github.com/jina-ai/finetuner/pull/580)) 
+
 ### Fixed
 
 ### Docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,32 +10,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Use latest Hubble with `notebook_login` support ([#576](https://github.com/jina-ai/finetuner/pull/576))
+- Use latest Hubble with `notebook_login` support. ([#576](https://github.com/jina-ai/finetuner/pull/576))
 
 ### Removed
 
 ### Changed
 
-- Update the open clip model names in the table of the backbones ([#580](https://github.com/jina-ai/finetuner/pull/580)) 
+- Update the open clip model names in the table of the backbones. ([#580](https://github.com/jina-ai/finetuner/pull/580)) 
 
 ### Fixed
 
 ### Docs
 
-- Fix training data name in totally looks like example ([#576](https://github.com/jina-ai/finetuner/pull/576))
+- Fix training data name in totally looks like example. ([#576](https://github.com/jina-ai/finetuner/pull/576))
 
 
 ## [0.6.3] - 2022-10-13
 
 ### Added
 
-- Support advanced CLIP fine-tuning with WiSE-FT ([#571](https://github.com/jina-ai/finetuner/pull/571))
+- Support advanced CLIP fine-tuning with WiSE-FT. ([#571](https://github.com/jina-ai/finetuner/pull/571))
 
 ### Removed
 
 ### Changed
 
-- Change CLIP fine-tuning example in the documentation ([#569](https://github.com/jina-ai/finetuner/pull/569))
+- Change CLIP fine-tuning example in the documentation. ([#569](https://github.com/jina-ai/finetuner/pull/569))
 
 ### Fixed
 
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Docs
 
-- Add documentation for callbacks ([#567](https://github.com/jina-ai/finetuner/pull/567))
+- Add documentation for callbacks. ([#567](https://github.com/jina-ai/finetuner/pull/567))
 
 
 ## [0.6.2] - 2022-09-29
@@ -58,7 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Freeze hubble client to `0.17.0` . ([#556](https://github.com/jina-ai/finetuner/pull/556))
+- Freeze hubble client to `0.17.0`. ([#556](https://github.com/jina-ai/finetuner/pull/556))
 
 ### Docs
 
@@ -137,21 +137,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Mark fit as login required. ([#494](https://github.com/jina-ai/finetuner/pull/494))
 
-- Improve documentation according to remarks we received ([524](https://github.com/jina-ai/finetuner/pull/524))
+- Improve documentation according to remarks we received. ([524](https://github.com/jina-ai/finetuner/pull/524))
 
 ### Fixed
 
 - Replace the artifact name from dot to dash. ([#519](https://github.com/jina-ai/finetuner/pull/519))
 
-- Create client automatically if user is already logged in ([#527](https://github.com/jina-ai/finetuner/pull/527))
+- Create client automatically if user is already logged in. ([#527](https://github.com/jina-ai/finetuner/pull/527))
 
 ### Docs
 
 - Fix google analytics Id for docs. ([#499](https://github.com/jina-ai/finetuner/pull/499))
 
-- Update sphinx-markdown-table to v0.0.16 to get [this fix](https://github.com/ryanfox/sphinx-markdown-tables/pull/37) ([#499](https://github.com/jina-ai/finetuner/pull/499))
+- Update sphinx-markdown-table to v0.0.16 to get. [this fix](https://github.com/ryanfox/sphinx-markdown-tables/pull/37) ([#499](https://github.com/jina-ai/finetuner/pull/499))
 
-- Place install instructions in the documentation more prominent ([#518](https://github.com/jina-ai/finetuner/pull/518))
+- Place install instructions in the documentation more prominent. ([#518](https://github.com/jina-ai/finetuner/pull/518))
 
 
 ## [0.5.1] - 2022-07-15

--- a/docs/walkthrough/choose-backbone.md
+++ b/docs/walkthrough/choose-backbone.md
@@ -21,54 +21,49 @@ finetuner.describe_models()
 To get a list of supported models:
 
 ```bash
-                                                         Finetuner backbones                                                         
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃                                     name ┃           task ┃ output_dim ┃ architecture ┃                               description ┃
-┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-│                          bert-base-cased │   text-to-text │        768 │  transformer │  BERT model pre-trained on BookCorpus and │
-│                                          │                │            │              │                         English Wikipedia │
-│             openai/clip-vit-base-patch16 │  text-to-image │        512 │  transformer │        CLIP base model with patch size 16 │
-│             openai/clip-vit-base-patch32 │  text-to-image │        512 │  transformer │                           CLIP base model │
-│        openai/clip-vit-large-patch14-336 │  text-to-image │        768 │  transformer │       CLIP large model for 336x336 images │
-│            openai/clip-vit-large-patch14 │  text-to-image │       1024 │  transformer │       CLIP large model with patch size 14 │
-│                          efficientnet_b0 │ image-to-image │       1280 │          cnn │   EfficientNet B0 pre-trained on ImageNet │
-│                          efficientnet_b4 │ image-to-image │       1792 │          cnn │   EfficientNet B4 pre-trained on ImageNet │
-│                             RN101#openai │  text-to-image │        512 │  transformer │            Open CLIP "RN101#openai" model │
-│                   RN101-quickgelu#openai │  text-to-image │        512 │  transformer │  Open CLIP "RN101-quickgelu#openai" model │
-│                  RN101-quickgelu#yfcc15m │  text-to-image │        512 │  transformer │ Open CLIP "RN101-quickgelu#yfcc15m" model │
-│                            RN101#yfcc15m │  text-to-image │        512 │  transformer │           Open CLIP "RN101#yfcc15m" model │
-│                               RN50#cc12m │  text-to-image │       1024 │  transformer │              Open CLIP "RN50#cc12m" model │
-│                              RN50#openai │  text-to-image │       1024 │  transformer │             Open CLIP "RN50#openai" model │
-│                     RN50-quickgelu#cc12m │  text-to-image │       1024 │  transformer │    Open CLIP "RN50-quickgelu#cc12m" model │
-│                    RN50-quickgelu#openai │  text-to-image │       1024 │  transformer │   Open CLIP "RN50-quickgelu#openai" model │
-│                   RN50-quickgelu#yfcc15m │  text-to-image │       1024 │  transformer │  Open CLIP "RN50-quickgelu#yfcc15m" model │
-│                           RN50x16#openai │  text-to-image │        768 │  transformer │          Open CLIP "RN50x16#openai" model │
-│                            RN50x4#openai │  text-to-image │        640 │  transformer │           Open CLIP "RN50x4#openai" model │
-│                           RN50x64#openai │  text-to-image │       1024 │  transformer │          Open CLIP "RN50x64#openai" model │
-│                             RN50#yfcc15m │  text-to-image │       1024 │  transformer │            Open CLIP "RN50#yfcc15m" model │
-│                   ViT-B-16#laion400m_e31 │  text-to-image │        512 │  transformer │  Open CLIP "ViT-B-16#laion400m_e31" model │
-│                   ViT-B-16#laion400m_e32 │  text-to-image │        512 │  transformer │  Open CLIP "ViT-B-16#laion400m_e32" model │
-│                          ViT-B-16#openai │  text-to-image │        512 │  transformer │         Open CLIP "ViT-B-16#openai" model │
-│          ViT-B-16-plus-240#laion400m_e31 │  text-to-image │        640 │  transformer │                                 Open CLIP │
-│                                          │                │            │              │   "ViT-B-16-plus-240#laion400m_e31" model │
-│          ViT-B-16-plus-240#laion400m_e32 │  text-to-image │        640 │  transformer │                                 Open CLIP │
-│                                          │                │            │              │   "ViT-B-16-plus-240#laion400m_e32" model │
-│                     ViT-B-32#laion2b_e16 │  text-to-image │        512 │  transformer │    Open CLIP "ViT-B-32#laion2b_e16" model │
-│                   ViT-B-32#laion400m_e31 │  text-to-image │        512 │  transformer │  Open CLIP "ViT-B-32#laion400m_e31" model │
-│                   ViT-B-32#laion400m_e32 │  text-to-image │        512 │  transformer │  Open CLIP "ViT-B-32#laion400m_e32" model │
-│                          ViT-B-32#openai │  text-to-image │        512 │  transformer │         Open CLIP "ViT-B-32#openai" model │
-│         ViT-B-32-quickgelu#laion400m_e31 │  text-to-image │        512 │  transformer │                                 Open CLIP │
-│                                          │                │            │              │  "ViT-B-32-quickgelu#laion400m_e31" model │
-│         ViT-B-32-quickgelu#laion400m_e32 │  text-to-image │        512 │  transformer │                                 Open CLIP │
-│                                          │                │            │              │  "ViT-B-32-quickgelu#laion400m_e32" model │
-│                ViT-B-32-quickgelu#openai │  text-to-image │        512 │  transformer │     Open CLIP "ViT-B-32-quickgelu#openai" │
-│                                          │                │            │              │                                     model │
-│                      ViT-L-14-336#openai │  text-to-image │        768 │  transformer │     Open CLIP "ViT-L-14-336#openai" model │
-│                          ViT-L-14#openai │  text-to-image │        768 │  transformer │         Open CLIP "ViT-L-14#openai" model │
-│                                resnet152 │ image-to-image │       2048 │          cnn │         ResNet152 pre-trained on ImageNet │
-│                                 resnet50 │ image-to-image │       2048 │          cnn │          ResNet50 pre-trained on ImageNet │
-│ sentence-transformers/msmarco-distilber… │   text-to-text │        768 │  transformer │   Pretrained BERT, fine-tuned on MS Marco │
-└──────────────────────────────────────────┴────────────────┴────────────┴──────────────┴───────────────────────────────────────────┘
+                                                                Finetuner backbones                                                                      
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                             name ┃           task ┃ output_dim ┃ architecture ┃                                                description ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│                                  bert-base-cased │   text-to-text │        768 │  transformer │ BERT model pre-trained on BookCorpus and English Wikipedia │
+│                     openai/clip-vit-base-patch16 │  text-to-image │        512 │  transformer │                         CLIP base model with patch size 16 │
+│                     openai/clip-vit-base-patch32 │  text-to-image │        512 │  transformer │                                            CLIP base model │
+│                openai/clip-vit-large-patch14-336 │  text-to-image │        768 │  transformer │                        CLIP large model for 336x336 images │
+│                    openai/clip-vit-large-patch14 │  text-to-image │       1024 │  transformer │                        CLIP large model with patch size 14 │
+│                                  efficientnet_b0 │ image-to-image │       1280 │          cnn │                    EfficientNet B0 pre-trained on ImageNet │
+│                                  efficientnet_b4 │ image-to-image │       1792 │          cnn │                    EfficientNet B4 pre-trained on ImageNet │
+│                                    RN101::openai │  text-to-image │        512 │  transformer │                            Open CLIP "RN101::openai" model │
+│                          RN101-quickgelu::openai │  text-to-image │        512 │  transformer │                  Open CLIP "RN101-quickgelu::openai" model │
+│                         RN101-quickgelu::yfcc15m │  text-to-image │        512 │  transformer │                 Open CLIP "RN101-quickgelu::yfcc15m" model │
+│                                   RN101::yfcc15m │  text-to-image │        512 │  transformer │                           Open CLIP "RN101::yfcc15m" model │
+│                                      RN50::cc12m │  text-to-image │       1024 │  transformer │                              Open CLIP "RN50::cc12m" model │
+│                                     RN50::openai │  text-to-image │       1024 │  transformer │                             Open CLIP "RN50::openai" model │
+│                            RN50-quickgelu::cc12m │  text-to-image │       1024 │  transformer │                    Open CLIP "RN50-quickgelu::cc12m" model │
+│                           RN50-quickgelu::openai │  text-to-image │       1024 │  transformer │                   Open CLIP "RN50-quickgelu::openai" model │
+│                          RN50-quickgelu::yfcc15m │  text-to-image │       1024 │  transformer │                  Open CLIP "RN50-quickgelu::yfcc15m" model │
+│                                  RN50x16::openai │  text-to-image │        768 │  transformer │                          Open CLIP "RN50x16::openai" model │
+│                                   RN50x4::openai │  text-to-image │        640 │  transformer │                           Open CLIP "RN50x4::openai" model │
+│                                  RN50x64::openai │  text-to-image │       1024 │  transformer │                          Open CLIP "RN50x64::openai" model │
+│                                    RN50::yfcc15m │  text-to-image │       1024 │  transformer │                            Open CLIP "RN50::yfcc15m" model │
+│                          ViT-B-16::laion400m_e31 │  text-to-image │        512 │  transformer │                  Open CLIP "ViT-B-16::laion400m_e31" model │
+│                          ViT-B-16::laion400m_e32 │  text-to-image │        512 │  transformer │                  Open CLIP "ViT-B-16::laion400m_e32" model │
+│                                 ViT-B-16::openai │  text-to-image │        512 │  transformer │                         Open CLIP "ViT-B-16::openai" model │
+│                 ViT-B-16-plus-240::laion400m_e31 │  text-to-image │        640 │  transformer │         Open CLIP "ViT-B-16-plus-240::laion400m_e31" model │
+│                 ViT-B-16-plus-240::laion400m_e32 │  text-to-image │        640 │  transformer │         Open CLIP "ViT-B-16-plus-240::laion400m_e32" model │
+│                            ViT-B-32::laion2b_e16 │  text-to-image │        512 │  transformer │                    Open CLIP "ViT-B-32::laion2b_e16" model │
+│                          ViT-B-32::laion400m_e31 │  text-to-image │        512 │  transformer │                  Open CLIP "ViT-B-32::laion400m_e31" model │
+│                          ViT-B-32::laion400m_e32 │  text-to-image │        512 │  transformer │                  Open CLIP "ViT-B-32::laion400m_e32" model │
+│                                 ViT-B-32::openai │  text-to-image │        512 │  transformer │                         Open CLIP "ViT-B-32::openai" model │
+│                ViT-B-32-quickgelu::laion400m_e31 │  text-to-image │        512 │  transformer │        Open CLIP "ViT-B-32-quickgelu::laion400m_e31" model │
+│                ViT-B-32-quickgelu::laion400m_e32 │  text-to-image │        512 │  transformer │        Open CLIP "ViT-B-32-quickgelu::laion400m_e32" model │
+│                       ViT-B-32-quickgelu::openai │  text-to-image │        512 │  transformer │               Open CLIP "ViT-B-32-quickgelu::openai" model │
+│                             ViT-L-14-336::openai │  text-to-image │        768 │  transformer │                     Open CLIP "ViT-L-14-336::openai" model │
+│                                 ViT-L-14::openai │  text-to-image │        768 │  transformer │                         Open CLIP "ViT-L-14::openai" model │
+│                                        resnet152 │ image-to-image │       2048 │          cnn │                          ResNet152 pre-trained on ImageNet │
+│                                         resnet50 │ image-to-image │       2048 │          cnn │                           ResNet50 pre-trained on ImageNet │
+│ sentence-transformers/msmarco-distilbert-base-v3 │   text-to-text │        768 │  transformer │                    Pretrained BERT, fine-tuned on MS Marco │
+└──────────────────────────────────────────────────┴────────────────┴────────────┴──────────────┴───────────────────────────────────────────────────────────
+
 ```
 + ResNets are suitable for image-to-image search tasks with high performance requirements, where `resnet152` is bigger and requires higher computational resources than `resnet50`.
 + EfficientNets are suitable for image-to-image search tasks with low training and inference times. The model is more light-weighted than ResNet. Here, `efficientnet_b4` is the bigger and more complex model.


### PR DESCRIPTION
Update names of open clip models
---

We are going to change the the separator in the names of the open clip models from `#` to `::`

- [ ] This PR references an open issue
- [x] I have added a line about this change to CHANGELOG