### PR TITLE
docs: unify everything to jina ai cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix training data name in totally looks like example. ([#576](https://github.com/jina-ai/finetuner/pull/576))
 
+- Unify documentation related to cloud storage as Jina AI Cloud. ([#582](https://github.com/jina-ai/finetuner/pull/582))
+
 
 ## [0.6.3] - 2022-10-13
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ With Finetuner, one can easily uplift pre-trained models to be more performant a
 
 🔱 **Simple yet powerful**: easy access to 40+ mainstream losses, 10+ optimisers, layer pruning, weights freezing, dimensionality reduction, hard-negative mining, cross-modal model, distributed training. 
 
-☁ **All-in-cloud**: instant training with our free GPU ([Apply here for free!](https://docs.google.com/forms/d/e/1FAIpQLSeoEhJM_TWMgZyEgJBBpf33JddcWQgXHNglNjVMIOvlLjk-4A/viewform)); manage runs, experiments and artifacts on Jina Cloud without worrying about provisioning resources, integration complexity and infrastructure.
+☁ **All-in-cloud**: instant training with our free GPU; manage runs, experiments and artifacts on Jina Cloud without worrying about provisioning resources, integration complexity and infrastructure.
 
 <!-- end elevator-pitch -->
 
@@ -161,7 +161,7 @@ run.save_artifact('resnet-tll')
 
 Specifically, the code snippet describes the following steps:
 
-  * Login to Finetuner ([Get free access here!](https://docs.google.com/forms/d/e/1FAIpQLSeoEhJM_TWMgZyEgJBBpf33JddcWQgXHNglNjVMIOvlLjk-4A/viewform))
+  * Login to Jina AI Cloud.
   * Select backbone model, training and evaluation data for your evaluation callback.
   * Start the cloud run.
   * Monitor the status: check the status and logs of the run.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ With Finetuner, one can easily uplift pre-trained models to be more performant a
 
 🔱 **Simple yet powerful**: easy access to 40+ mainstream losses, 10+ optimisers, layer pruning, weights freezing, dimensionality reduction, hard-negative mining, cross-modal model, distributed training. 
 
-☁ **All-in-cloud**: instant training with our free GPU; manage runs, experiments and artifacts on Jina Cloud without worrying about provisioning resources, integration complexity and infrastructure.
+☁ **All-in-cloud**: instant training with our free GPU; manage runs, experiments and artifacts on Jina AI Cloud without worrying about provisioning resources, integration complexity and infrastructure.
 
 <!-- end elevator-pitch -->
 
@@ -115,7 +115,7 @@ pip install "finetuner[full]"
 
 <!-- end install-instruction -->
 
-> From 0.5.0, Finetuner computing is hosted on Jina Cloud. THe last local version is `0.4.1`, one can install it via pip or check out [git tags/releases here](https://github.com/jina-ai/finetuner/releases).
+> From 0.5.0, Finetuner computing is hosted on Jina AI Cloud. THe last local version is `0.4.1`, one can install it via pip or check out [git tags/releases here](https://github.com/jina-ai/finetuner/releases).
 
 
 

--- a/docs/_templates/template_ft_in_action.md
+++ b/docs/_templates/template_ft_in_action.md
@@ -13,7 +13,7 @@ Also provide a brief description of what the task entails, what the dataset look
 
 
 ## Preparing data
-Outline where the data can be found, artifact names in hubble or if relevant, how a user might load their own custom data. 
+Outline where the data can be found, artifact names in Jina AI Cloud or if relevant, how a user might load their own custom data. 
 Add a link to supplementary dataset info, for example as a `See Also` {admonition}.
 If you are outlining how to preprocess a dataset from scratch, use {dropdown} to hide long code snippets.
 

--- a/docs/tasks/image-to-image.md
+++ b/docs/tasks/image-to-image.md
@@ -18,7 +18,7 @@ After fine-tuning, the embeddings of positive pairs are expected to be pulled cl
 
 
 ## Data
-Our journey starts locally. We have to {ref}`prepare the data and push it to the Jina AI Cloud <create-training-data>` and Finetuner will be able to get the dataset by its name. For this example,
+Our journey starts locally. We have to {ref}`prepare the data and push them to the Jina AI Cloud <create-training-data>` and Finetuner will be able to get the dataset by its name. For this example,
 we already prepared the data, and we'll provide the names of training data (`tll-train-da`) directly to Finetuner.
 
 ```{admonition} 

--- a/docs/tasks/image-to-image.md
+++ b/docs/tasks/image-to-image.md
@@ -18,12 +18,12 @@ After fine-tuning, the embeddings of positive pairs are expected to be pulled cl
 
 
 ## Data
-Our journey starts locally. We have to {ref}`prepare the data and push it to the cloud <create-training-data>` and Finetuner will be able to get the dataset by its name. For this example,
+Our journey starts locally. We have to {ref}`prepare the data and push it to the Jina AI Cloud <create-training-data>` and Finetuner will be able to get the dataset by its name. For this example,
 we already prepared the data, and we'll provide the names of training data (`tll-train-da`) directly to Finetuner.
 
 ```{admonition} 
 :class: tip
-We don't require you to push data to the cloud by yourself. Instead of a name, you can provide a `DocumentArray` and Finetuner will do the job for you.
+We don't require you to push data to the Jina AI Cloud by yourself. Instead of a name, you can provide a `DocumentArray` and Finetuner will do the job for you.
 ```
 
 ```{important}
@@ -38,9 +38,9 @@ Now let's see which backbone models we can use. You can see available models eit
 For this example, we're gonna go with `resnet50`.
 
 ## Fine-tuning
-From now on, all the action happens in the cloud! 
+From now on, all the action happens in the Jina AI Cloud! 
 
-First, {ref}`log in to the Jina ecosystem <login-to-jina-ecosystem>`:
+First, {ref}`log in to the Jina AI Cloud <login-to-jina-ecosystem>`:
 ```python
 import finetuner
 finetuner.login()  # use finetuner.notebook_login() in Jupyter notebook or Google Colab

--- a/docs/tasks/image-to-image.md
+++ b/docs/tasks/image-to-image.md
@@ -143,7 +143,7 @@ from docarray import Document, DocumentArray
 # Prepare an image to encode, change the placeholder image uri to an image on your machine
 test_da = DocumentArray([Document(uri='my-image.png')])
 # Load model from artifact
-model = finetuner.get_model(artifact=artifact)
+model = finetuner.get_model(artifact=artifact, device='cuda')
 # Encoding will happen in-place in your `DocumentArray`
 finetuner.encode(model=model, data=test_da)
 print(test_da.embeddings)

--- a/docs/tasks/text-to-image.md
+++ b/docs/tasks/text-to-image.md
@@ -134,8 +134,8 @@ from docarray import Document, DocumentArray
 text_da = DocumentArray([Document(text='some text to encode')])
 image_da = DocumentArray([Document(uri='my-image.png')])
 # Load model from artifact
-clip_text_encoder = finetuner.get_model(artifact=artifact, select_model='clip-text')
-clip_image_encoder = finetuner.get_model(artifact=artifact, select_model='clip-vision')
+clip_text_encoder = finetuner.get_model(artifact=artifact, device='cuda', select_model='clip-text')
+clip_image_encoder = finetuner.get_model(artifact=artifact, device='cuda', select_model='clip-vision')
 # Encoding will happen in-place in your `DocumentArray`
 finetuner.encode(model=clip_text_encoder, data=text_da)
 finetuner.encode(model=clip_image_encoder, data=image_da)

--- a/docs/tasks/text-to-image.md
+++ b/docs/tasks/text-to-image.md
@@ -10,12 +10,12 @@ For each product the dataset contains a title and images of multiple variants of
 
 
 ## Data
-Our journey starts locally. We have to {ref}`prepare the data and push it to the cloud <create-training-data>` and Finetuner will be able to get the dataset by its name. For this example,
+Our journey starts locally. We have to {ref}`prepare the data and push it to the Jina AI Cloud <create-training-data>` and Finetuner will be able to get the dataset by its name. For this example,
 we already prepared the data, and we'll provide the names of training and evaluation data (`fashion-train-data-clip` and `fashion-eval-data-clip`) directly to Finetuner.
 
 ```{admonition} 
 :class: tip
-We don't require you to push data to the cloud by yourself. Instead of a name, you can provide a `DocumentArray` and Finetuner will do the job for you.
+We don't require you to push data to the Jina AI Cloud by yourself. Instead of a name, you can provide a `DocumentArray` and Finetuner will do the job for you.
 ```
 
 
@@ -24,9 +24,9 @@ Currently, we only support `openai/clip-vit-base-patch32` for text to image retr
 
 
 ## Fine-tuning
-From now on, all the action happens in the cloud! 
+From now on, all the action happens in the Jina AI Cloud! 
 
-First you need to {ref}`login to Jina ecosystem <login-to-jina-ecosystem>`:
+First you need to {ref}`login to Jina AI Cloud <login-to-jina-ecosystem>`:
 ```python
 import finetuner
 finetuner.login()  # use finetuner.notebook_login() in Jupyter notebook or Google Colab

--- a/docs/tasks/text-to-image.md
+++ b/docs/tasks/text-to-image.md
@@ -10,7 +10,7 @@ For each product the dataset contains a title and images of multiple variants of
 
 
 ## Data
-Our journey starts locally. We have to {ref}`prepare the data and push it to the Jina AI Cloud <create-training-data>` and Finetuner will be able to get the dataset by its name. For this example,
+Our journey starts locally. We have to {ref}`prepare the data and push them to the Jina AI Cloud <create-training-data>` and Finetuner will be able to get the dataset by its name. For this example,
 we already prepared the data, and we'll provide the names of training and evaluation data (`fashion-train-data-clip` and `fashion-eval-data-clip`) directly to Finetuner.
 
 ```{admonition} 

--- a/docs/tasks/text-to-text.md
+++ b/docs/tasks/text-to-text.md
@@ -102,7 +102,7 @@ Now that we have the training and evaluation datasets loaded as `DocumentArray`s
 import finetuner
 from finetuner.callback import EvaluationCallback
 
-# Make sure to login to Jina Cloud
+# Make sure to login to Jina AI Cloud
 finetuner.login()  # use finetuner.notebook_login() in Jupyter notebook or Google Colab
 
 # Start fine-tuning as a run within an experiment

--- a/docs/tasks/text-to-text.md
+++ b/docs/tasks/text-to-text.md
@@ -39,7 +39,7 @@ Supplementary information about the Quora Question Pairs dataset can be found on
 
 ## Data
 
-We will use the [Quora Question Pairs](https://www.sbert.net/examples/training/quora_duplicate_questions/README.html?highlight=quora#dataset) dataset to show-case Finetuner for text to text search. We have already pre-processed this dataset and made it available for you to pull from hubble. Do this as follows:
+We will use the [Quora Question Pairs](https://www.sbert.net/examples/training/quora_duplicate_questions/README.html?highlight=quora#dataset) dataset to show-case Finetuner for text to text search. We have already pre-processed this dataset and made it available for you to pull from Jina AI Cloud. Do this as follows:
 
 ```python
 from docarray import DocumentArray

--- a/docs/tasks/text-to-text.md
+++ b/docs/tasks/text-to-text.md
@@ -210,7 +210,7 @@ from docarray import Document, DocumentArray
 # Prepare some text to encode
 test_da = DocumentArray([Document(text='some text to encode')])
 # Load model from artifact
-model = finetuner.get_model(artifact=artifact)
+model = finetuner.get_model(artifact=artifact, device='cuda')
 # Encoding will happen in-place in your `DocumentArray`
 finetuner.encode(model=model, data=test_da)
 print(test_da.embeddings.shape)

--- a/docs/walkthrough/index.md
+++ b/docs/walkthrough/index.md
@@ -21,7 +21,7 @@ to address this by providing a simple interface, which can be as easy as:
 import finetuner
 from docarray import DocumentArray
 
-# Login to Jina ecosystem
+# Login to Jina AI Cloud
 finetuner.login()  # use finetuner.notebook_login() in Jupyter notebook or Google Colab
 
 # Prepare training data

--- a/docs/walkthrough/index.md
+++ b/docs/walkthrough/index.md
@@ -58,7 +58,7 @@ Run logs:
            INFO     [__main__] Finished 🚀                       __main__.py:240
 ```
 
-Submitted fine-tuning jobs run efficiently on the Jina Cloud on either CPU or GPU enabled hardware.
+Submitted fine-tuning jobs run efficiently on the Jina AI Cloud on either CPU or GPU enabled hardware.
 
 Finetuner fully owns the complexity of setting up and maintaining the model training infrastructure plus the complexity of delivering SOTA training methods to production use cases.
 

--- a/docs/walkthrough/integrate-with-jina.md
+++ b/docs/walkthrough/integrate-with-jina.md
@@ -21,7 +21,11 @@ run = finetuner.get_run(
     run_name='YOUR-RUN'
 )
 
-model = finetuner.get_model(run.artifact_id, token=token)
+model = finetuner.get_model(
+    run.artifact_id,
+    token=token,
+    device='cuda', # model will be placed on cpu by default.
+)
 
 da = DocumentArray([Document(text='some text to encode')])
 
@@ -180,7 +184,12 @@ run = finetuner.get_run(
     run_name='YOUR-RUN'
 )
 
-model = finetuner.get_model(run.artifact_id, token=token, select_model='clip-text')
+model = finetuner.get_model(
+    run.artifact_id,
+    token=token,
+    device='cuda',
+    select_model='clip-text'
+)
 
 da = DocumentArray([Document(text='some text to encode')])
 
@@ -200,7 +209,12 @@ run = finetuner.get_run(
     run_name='YOUR-RUN'
 )
 
-model = finetuner.get_model(run.artifact_id, token=token, select_model='clip-vision')
+model = finetuner.get_model(
+    run.artifact_id,
+    token=token,
+    device='cuda',
+    select_model='clip-vision'
+)
 
 da = DocumentArray([Document(text='~/Pictures/my_img.png')])
 

--- a/docs/walkthrough/integrate-with-jina.md
+++ b/docs/walkthrough/integrate-with-jina.md
@@ -63,7 +63,7 @@ please use `model = finetuner.get_model('/path/to/YOUR-MODEL.zip', is_onnx=True)
 (integrate-with-jina)=
 ## Fine-tuned model as Executor
 
-Finetuner, being part of the Jina ecosystem, provides a convenient way to use tuned models via [Jina Executors](https://docs.jina.ai/fundamentals/executor/).
+Finetuner, being part of the Jina AI Cloud, provides a convenient way to use tuned models via [Jina Executors](https://docs.jina.ai/fundamentals/executor/).
 
 We've created the [`FinetunerExecutor`](https://hub.jina.ai/executor/13dzxycc) which can be added in a [Jina Flow](https://docs.jina.ai/fundamentals/flow/) and load any tuned model. 
 More specifically, the executor exposes an `/encode` endpoint that embeds [Documents](https://docarray.jina.ai/fundamentals/document/) using the fine-tuned model.
@@ -118,7 +118,7 @@ executors:
 As you can see, it's super easy! 
 If you did not call `save_artifact`,
 you need to provide the `artifact_id` and `token`.
-`FinetunerExecutor` will automatically pull your model from the cloud storage to the container.
+`FinetunerExecutor` will automatically pull your model from the Jina AI Cloud to the container.
 
 On the other hand,
 if you have saved artifact locally,

--- a/docs/walkthrough/login.md
+++ b/docs/walkthrough/login.md
@@ -20,8 +20,8 @@ After {meth}`~finetuner.login()` or `~finetuner.notebook_login()` you will see t
 
 ```{admonition} Why do I need to login?
 :class: hint
-Login is required since Finetuner needs to push your {class}`~docarray.array.document.DocumentArray` into the cloud as training data.
+Login is required since Finetuner needs to push your {class}`~docarray.array.document.DocumentArray` into the Jina AI Cloud as training data.
 Once you have successfully logged in, your training data will be linked to your personal user profile and will only be visible to you.
 
-Once fine-tuning is completed, the fine-tuned model will be visible only to you in the cloud.
+Once fine-tuning is completed, the fine-tuned model will be visible only to you in the Jina AI Cloud.
 ```

--- a/docs/walkthrough/run-job.md
+++ b/docs/walkthrough/run-job.md
@@ -35,7 +35,7 @@ During fine-tuning,
 the run status changes from:
 1. CREATED: the {class}`~finetuner.run.Run` has been created and submitted to the job queue.
 2. STARTED: the job is in progress
-3. FINISHED: the job finished successfully, model has been sent to cloud storage.
+3. FINISHED: the job finished successfully, model has been sent to Jina AI Cloud.
 4. FAILED: the job failed, please check the logs for more details.
 
 ## Advanced configurations

--- a/docs/walkthrough/save-model.md
+++ b/docs/walkthrough/save-model.md
@@ -2,8 +2,8 @@
 # Save Artifact
 
 Perfect!
-Now, you have started the fine-tuning job in the cloud.
-When the fine-tuning job is finished, the resulting model is automatically stored under your Jina account in the cloud.
+Now, you have started the fine-tuning job in the Jina AI Cloud.
+When the fine-tuning job is finished, the resulting model is automatically stored under your Jina account in the Jina AI Cloud.
 Next, we can get its artifact id and download the model.
 
 ```{admonition} Managing fine-tuned models

--- a/docs/walkthrough/using-callbacks.md
+++ b/docs/walkthrough/using-callbacks.md
@@ -43,7 +43,7 @@ The evaluation callback is used to calculate performance metrics for the model b
 ```
 
 The evaluation callback is triggered at the end of each epoch, in which the model is evaluated using the `query_data` and `index_data` datasets that were provided when the callback was created.
-It is worth noting that the evaluation callback and the `eval_data` parameter of the fit method do not do the same thing. The eval data parameter takes a `DocumentArray` (or the name of one that has been pushed on the cloud) and uses its contents to evaluate the loss of the model whereas the evaluation callback is used to evaluate the quality of the searches using metrics such as average precision and recall. These search metrics can be used by other callbacks if the evaluation callback is first in the list of callbacks when creating a run.
+It is worth noting that the evaluation callback and the `eval_data` parameter of the fit method do not do the same thing. The eval data parameter takes a `DocumentArray` (or the name of one that has been pushed on the Jina AI Cloud) and uses its contents to evaluate the loss of the model whereas the evaluation callback is used to evaluate the quality of the searches using metrics such as average precision and recall. These search metrics can be used by other callbacks if the evaluation callback is first in the list of callbacks when creating a run.
 
 ## BestModelCheckpoint
 


### PR DESCRIPTION
<!--- PR Description here --->

A list of documentation improvements before release:

1. everything related to cloud storage, Hubble, ecosystem renamed to Jina AI Cloud.
2. document `device='cuda'` in `get_model`.
3. Remove gpu application form.

---

- [ ] This PR references an open issue
- [x] I have added a line about this change to CHANGELOG