### PR TITLE
refactor: show progress while encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update the open clip model names in the table of the backbones. ([#580](https://github.com/jina-ai/finetuner/pull/580))
 
+- Show progress while encode batches of documents. ([#586](https://github.com/jina-ai/finetuner/pull/586))
+
+- Change `device` as an optional parameter when calling `get_model`. ([#586](https://github.com/jina-ai/finetuner/pull/586))
+
 ### Fixed
 
 ### Docs

--- a/finetuner/__init__.py
+++ b/finetuner/__init__.py
@@ -313,7 +313,7 @@ def get_model(
     token: Optional[str] = None,
     batch_size: int = 32,
     select_model: Optional[str] = None,
-    device: str = 'cpu',
+    device: Optional[str] = None,
     logging_level: str = 'WARNING',
     is_onnx: bool = False,
 ):
@@ -343,10 +343,14 @@ def get_model(
     ..Note::
       please install finetuner[full] to include all the dependencies.
     """
+    import torch
     from commons.models.inference import (
         ONNXRuntimeInferenceEngine,
         TorchInferenceEngine,
     )
+
+    if not device:
+        device = 'cuda' if torch.cuda.is_available() else 'cpu'
 
     if device == 'cuda' and is_onnx:
         warnings.warn(

--- a/finetuner/__init__.py
+++ b/finetuner/__init__.py
@@ -396,7 +396,7 @@ def encode(
     """
     from commons.models.inference import ONNXRuntimeInferenceEngine
 
-    for batch in data.batch(batch_size):
+    for batch in data.batch(batch_size, show_progress=True):
         if isinstance(model, ONNXRuntimeInferenceEngine):
             inputs = model._run_data_pipeline(batch)
             inputs = model._flatten_inputs(inputs)

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ if __name__ == '__main__':
         zip_safe=False,
         setup_requires=['setuptools>=18.0', 'wheel'],
         install_requires=[
-            'docarray[common]>=0.13.31',
+            'docarray[common]>=0.18.0',
             'finetuner-stubs==0.10.4',
             'jina-hubble-sdk==0.21.0',
         ],


### PR DESCRIPTION
<!--- PR Description here --->

Usability improvements `encode`:

1. interpret device type if `device` is not provided.
2. `show_progress` while batching DocumentArray when calling `encode`.

---

- [ ] This PR references an open issue
- [x] I have added a line about this change to CHANGELOG