### PR TITLE
docs: upgrade to new hub uri to cloud uri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Unify documentation related to cloud storage as Jina AI Cloud. ([#582](https://github.com/jina-ai/finetuner/pull/582))
 
+- Replace `hub.jina.ai` with `cloud.jina.ai`. ([#587](https://github.com/jina-ai/finetuner/pull/587))
+
 
 ## [0.6.3] - 2022-10-13
 

--- a/docs/_templates/sidebar/navigation.html
+++ b/docs/_templates/sidebar/navigation.html
@@ -7,7 +7,7 @@
                 <img class="sidebar-ecosys-logo only-light-line" src="{{ pathto('_static/search-light.svg', 1) }}">
                 <img class="sidebar-ecosys-logo only-dark-line" src="{{ pathto('_static/search-dark.svg', 1) }}">
                 Jina</a></li>
-        <li class="toctree-l1"><a class="reference external" href="https://hub.jina.ai">
+        <li class="toctree-l1"><a class="reference external" href="https://cloud.jina.ai">
             <img class="sidebar-ecosys-logo only-light-line" src="{{ pathto('_static/hub-light.svg', 1) }}">
             <img class="sidebar-ecosys-logo only-dark-line" src="{{ pathto('_static/hub-dark.svg', 1) }}">
             Jina Hub</a></li>

--- a/docs/walkthrough/integrate-with-jina.md
+++ b/docs/walkthrough/integrate-with-jina.md
@@ -69,7 +69,7 @@ please use `model = finetuner.get_model('/path/to/YOUR-MODEL.zip', is_onnx=True)
 
 Finetuner, being part of the Jina AI Cloud, provides a convenient way to use tuned models via [Jina Executors](https://docs.jina.ai/fundamentals/executor/).
 
-We've created the [`FinetunerExecutor`](https://hub.jina.ai/executor/13dzxycc) which can be added in a [Jina Flow](https://docs.jina.ai/fundamentals/flow/) and load any tuned model. 
+We've created the [`FinetunerExecutor`](https://cloud.jina.ai/executor/13dzxycc) which can be added in a [Jina Flow](https://docs.jina.ai/fundamentals/flow/) and load any tuned model. 
 More specifically, the executor exposes an `/encode` endpoint that embeds [Documents](https://docarray.jina.ai/fundamentals/document/) using the fine-tuned model.
 
 Loading a tuned model is simple! You just need to provide a few parameters under the `uses_with` argument when adding the `FinetunerExecutor` to the [Flow]((https://docs.jina.ai/fundamentals/flow/)).
@@ -155,7 +155,7 @@ Text of the returned document: some text to encode
 Shape of the embedding: (768,)
 ```
 
-In order to see what other options you can specify when initializing the executor, please go to the [`FinetunerExecutor`](https://hub.jina.ai/executor/13dzxycc) page and click on `Arguments` on the top-right side.
+In order to see what other options you can specify when initializing the executor, please go to the [`FinetunerExecutor`](https://cloud.jina.ai/executor/13dzxycc) page and click on `Arguments` on the top-right side.
 
 ```{admonition} FinetunerExecutor parameters
 :class: tip


### PR DESCRIPTION
<!--- PR Description here --->

`hub.jina.ai` has been replaced with `cloud.jina.ai`.

---

- [ ] This PR references an open issue
- [x] I have added a line about this change to CHANGELOG