### PR TITLE
refactor: add docs and remove connect function

### DIFF
--- a/docs/walkthrough/login.md
+++ b/docs/walkthrough/login.md
@@ -18,6 +18,13 @@ After {meth}`~finetuner.login()` or `~finetuner.notebook_login()` you will see t
 🔐 Successfully logged in to Jina AI as [USER NAME]!
 ```
 
+ Now, an authentication token is generated which can be read with the {func}:`~finetuner.get_token` function.
+If you have been logged in before, the existing token will not be overwritten, however, if you want this to be happen, you can set the `force` attribute in the login function to true.
+
+```
+finetuner.login(force=True)
+```
+
 ```{admonition} Why do I need to login?
 :class: hint
 Login is required since Finetuner needs to push your {class}`~docarray.array.document.DocumentArray` into the Jina AI Cloud as training data.

--- a/finetuner/__init__.py
+++ b/finetuner/__init__.py
@@ -34,16 +34,19 @@ if TYPE_CHECKING:
 ft = Finetuner()
 
 
-def login(force: bool = False):
+def login(force: bool = False) -> None:
+    """
+    Login to Jina AI to use cloud-based fine-tuning. Thereby, a authentication token is
+    generated which can be read with the {func}:`~finetuner.get_token` function.
+
+    :param force: If set to true, an existing token will be overwritten. Otherwise,
+        you will not login again, if a valid token already exists.
+    """
     ft.login(force=force)
 
 
 def notebook_login(force: bool = False):
     ft.notebook_login(force=force)
-
-
-def connect():
-    ft.connect()
 
 
 def list_callbacks() -> Dict[str, callback.CallbackStubType]:

--- a/finetuner/finetuner.py
+++ b/finetuner/finetuner.py
@@ -40,12 +40,6 @@ class Finetuner:
         """
         hubble.notebook_login(force=force, post_success=self._init_state)
 
-    def connect(self):
-        """Connects finetuner to Hubble without logging in again.
-        Use this function, if you are already logged in.
-        """
-        self._init_state()
-
     @staticmethod
     def _get_cwd() -> str:
         """Returns current working directory."""


### PR DESCRIPTION
This PR fix some minor issues with the login functionalities
- add docstring to login function
- add documentation for the force parameter
- remove `connect` function which got useless since the `force` parameter was introduced by hubble
---

- [ ] This PR references an open issue
- [ ] I have added a line about this change to CHANGELOG