### PR TITLE
add comment for run name

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ pip install "finetuner[full]"
   
 ## Get Started
 
-The following code snippet describes how to fine-tune ResNet50 on [Totally Looks Like dataset](https://sites.google.com/view/totally-looks-like-dataset), it can be run as-is:
+The following code snippet describes how to fine-tune ResNet50 on [Totally Looks Like dataset](https://sites.google.com/view/totally-looks-like-dataset), it can be run as-is (If there is already a run called `resnet50-tll-run`, choose a different name):
 
 ```python
 import finetuner


### PR DESCRIPTION
Add comment abou run name in README
---
If users run the example in the README twice, they might wonder about this exception:
```bash
finetuner.excepts.FinetunerServerError: Conflict (409): Run 'resnet50-tll-run' for experiment 'finetuner' already exists
```
Therefore, I would suggest to add a note about run names to be unique.

- [ ] This PR references an open issue
- [ ] I have added a line about this change to CHANGELOG