### PR TITLE
docs: better describe models on task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Docs
 
+- Improve `describe_model` with `task` to better organize list of backbones. ([#610](https://github.com/jina-ai/finetuner/pull/610))
+
 
 ## [0.6.5] - 2022-11-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Docs
 
-- Improve `describe_model` with `task` to better organize list of backbones. ([#610](https://github.com/jina-ai/finetuner/pull/610))
+- Improve `describe_models` with `task` to better organize list of backbones. ([#610](https://github.com/jina-ai/finetuner/pull/610))
 
 
 ## [0.6.5] - 2022-11-10

--- a/docs/walkthrough/choose-backbone.md
+++ b/docs/walkthrough/choose-backbone.md
@@ -12,11 +12,27 @@ The embedding model can be fine-tuned for text-to-text, image-to-image or text-t
 search tasks.
 
 You can call:
+````{tab} text-to-text
 ```python
 import finetuner
 
-finetuner.describe_models()
+finetuner.describe_models(task='text-to-text')
 ```
+````
+````{tab} image-to-image
+```python
+import finetuner
+
+finetuner.describe_models(task='image-to-image')
+```
+````
+````{tab} text-to-image
+```python
+import finetuner
+
+finetuner.describe_models(task='text-to-image')
+```
+````
 
 To get a list of supported models:
 

--- a/docs/walkthrough/choose-backbone.md
+++ b/docs/walkthrough/choose-backbone.md
@@ -38,23 +38,73 @@ To get a list of supported models:
 
 ````{tab} text-to-text
 ```bash
-import finetuner
-
-finetuner.describe_models(task='text-to-text')
+                                              Finetuner backbones: text-to-text                                               
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                   name ┃         task ┃ output_dim ┃ architecture ┃                            description ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│                        bert-base-cased │ text-to-text │        768 │  transformer │   BERT model pre-trained on BookCorpus │
+│                                        │              │            │              │                  and English Wikipedia │
+│ sentence-transformers/msmarco-distilb… │ text-to-text │        768 │  transformer │      Pretrained BERT, fine-tuned on MS │
+│                                        │              │            │              │                                  Marco │
+└────────────────────────────────────────┴──────────────┴────────────┴──────────────┴────────────────────────────────────────┘
 ```
 ````
 ````{tab} image-to-image
 ```bash
-import finetuner
-
-finetuner.describe_models(task='image-to-image')
+                                   Finetuner backbones: image-to-image                                    
+┏━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃            name ┃           task ┃ output_dim ┃ architecture ┃                             description ┃
+┡━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ efficientnet_b0 │ image-to-image │       1280 │          cnn │ EfficientNet B0 pre-trained on ImageNet │
+│ efficientnet_b4 │ image-to-image │       1792 │          cnn │ EfficientNet B4 pre-trained on ImageNet │
+│       resnet152 │ image-to-image │       2048 │          cnn │       ResNet152 pre-trained on ImageNet │
+│        resnet50 │ image-to-image │       2048 │          cnn │        ResNet50 pre-trained on ImageNet │
+└─────────────────┴────────────────┴────────────┴──────────────┴─────────────────────────────────────────┘
 ```
 ````
 ````{tab} text-to-image
 ```bash
-import finetuner
-
-finetuner.describe_models(task='text-to-image')
+                                              Finetuner backbones: text-to-image                                              
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                              name ┃          task ┃ output_dim ┃ architecture ┃                                description ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│      openai/clip-vit-base-patch16 │ text-to-image │        512 │  transformer │         CLIP base model with patch size 16 │
+│      openai/clip-vit-base-patch32 │ text-to-image │        512 │  transformer │                            CLIP base model │
+│ openai/clip-vit-large-patch14-336 │ text-to-image │        768 │  transformer │        CLIP large model for 336x336 images │
+│     openai/clip-vit-large-patch14 │ text-to-image │       1024 │  transformer │        CLIP large model with patch size 14 │
+│                     RN101::openai │ text-to-image │        512 │  transformer │            Open CLIP "RN101::openai" model │
+│           RN101-quickgelu::openai │ text-to-image │        512 │  transformer │  Open CLIP "RN101-quickgelu::openai" model │
+│          RN101-quickgelu::yfcc15m │ text-to-image │        512 │  transformer │ Open CLIP "RN101-quickgelu::yfcc15m" model │
+│                    RN101::yfcc15m │ text-to-image │        512 │  transformer │           Open CLIP "RN101::yfcc15m" model │
+│                       RN50::cc12m │ text-to-image │       1024 │  transformer │              Open CLIP "RN50::cc12m" model │
+│                      RN50::openai │ text-to-image │       1024 │  transformer │             Open CLIP "RN50::openai" model │
+│             RN50-quickgelu::cc12m │ text-to-image │       1024 │  transformer │    Open CLIP "RN50-quickgelu::cc12m" model │
+│            RN50-quickgelu::openai │ text-to-image │       1024 │  transformer │   Open CLIP "RN50-quickgelu::openai" model │
+│           RN50-quickgelu::yfcc15m │ text-to-image │       1024 │  transformer │  Open CLIP "RN50-quickgelu::yfcc15m" model │
+│                   RN50x16::openai │ text-to-image │        768 │  transformer │          Open CLIP "RN50x16::openai" model │
+│                    RN50x4::openai │ text-to-image │        640 │  transformer │           Open CLIP "RN50x4::openai" model │
+│                   RN50x64::openai │ text-to-image │       1024 │  transformer │          Open CLIP "RN50x64::openai" model │
+│                     RN50::yfcc15m │ text-to-image │       1024 │  transformer │            Open CLIP "RN50::yfcc15m" model │
+│           ViT-B-16::laion400m_e31 │ text-to-image │        512 │  transformer │  Open CLIP "ViT-B-16::laion400m_e31" model │
+│           ViT-B-16::laion400m_e32 │ text-to-image │        512 │  transformer │  Open CLIP "ViT-B-16::laion400m_e32" model │
+│                  ViT-B-16::openai │ text-to-image │        512 │  transformer │         Open CLIP "ViT-B-16::openai" model │
+│  ViT-B-16-plus-240::laion400m_e31 │ text-to-image │        640 │  transformer │                                  Open CLIP │
+│                                   │               │            │              │   "ViT-B-16-plus-240::laion400m_e31" model │
+│  ViT-B-16-plus-240::laion400m_e32 │ text-to-image │        640 │  transformer │                                  Open CLIP │
+│                                   │               │            │              │   "ViT-B-16-plus-240::laion400m_e32" model │
+│             ViT-B-32::laion2b_e16 │ text-to-image │        512 │  transformer │    Open CLIP "ViT-B-32::laion2b_e16" model │
+│           ViT-B-32::laion400m_e31 │ text-to-image │        512 │  transformer │  Open CLIP "ViT-B-32::laion400m_e31" model │
+│           ViT-B-32::laion400m_e32 │ text-to-image │        512 │  transformer │  Open CLIP "ViT-B-32::laion400m_e32" model │
+│                  ViT-B-32::openai │ text-to-image │        512 │  transformer │         Open CLIP "ViT-B-32::openai" model │
+│ ViT-B-32-quickgelu::laion400m_e31 │ text-to-image │        512 │  transformer │                                  Open CLIP │
+│                                   │               │            │              │  "ViT-B-32-quickgelu::laion400m_e31" model │
+│ ViT-B-32-quickgelu::laion400m_e32 │ text-to-image │        512 │  transformer │                                  Open CLIP │
+│                                   │               │            │              │  "ViT-B-32-quickgelu::laion400m_e32" model │
+│        ViT-B-32-quickgelu::openai │ text-to-image │        512 │  transformer │     Open CLIP "ViT-B-32-quickgelu::openai" │
+│                                   │               │            │              │                                      model │
+│              ViT-L-14-336::openai │ text-to-image │        768 │  transformer │     Open CLIP "ViT-L-14-336::openai" model │
+│                  ViT-L-14::openai │ text-to-image │        768 │  transformer │         Open CLIP "ViT-L-14::openai" model │
+└───────────────────────────────────┴───────────────┴────────────┴──────────────┴────────────────────────────────────────────┘
 ```
 ````
 

--- a/docs/walkthrough/choose-backbone.md
+++ b/docs/walkthrough/choose-backbone.md
@@ -36,51 +36,28 @@ finetuner.describe_models(task='text-to-image')
 
 To get a list of supported models:
 
+````{tab} text-to-text
 ```bash
-                                                                Finetuner backbones                                                                      
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃                                             name ┃           task ┃ output_dim ┃ architecture ┃                                                description ┃
-┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-│                                  bert-base-cased │   text-to-text │        768 │  transformer │ BERT model pre-trained on BookCorpus and English Wikipedia │
-│                     openai/clip-vit-base-patch16 │  text-to-image │        512 │  transformer │                         CLIP base model with patch size 16 │
-│                     openai/clip-vit-base-patch32 │  text-to-image │        512 │  transformer │                                            CLIP base model │
-│                openai/clip-vit-large-patch14-336 │  text-to-image │        768 │  transformer │                        CLIP large model for 336x336 images │
-│                    openai/clip-vit-large-patch14 │  text-to-image │       1024 │  transformer │                        CLIP large model with patch size 14 │
-│                                  efficientnet_b0 │ image-to-image │       1280 │          cnn │                    EfficientNet B0 pre-trained on ImageNet │
-│                                  efficientnet_b4 │ image-to-image │       1792 │          cnn │                    EfficientNet B4 pre-trained on ImageNet │
-│                                    RN101::openai │  text-to-image │        512 │  transformer │                            Open CLIP "RN101::openai" model │
-│                          RN101-quickgelu::openai │  text-to-image │        512 │  transformer │                  Open CLIP "RN101-quickgelu::openai" model │
-│                         RN101-quickgelu::yfcc15m │  text-to-image │        512 │  transformer │                 Open CLIP "RN101-quickgelu::yfcc15m" model │
-│                                   RN101::yfcc15m │  text-to-image │        512 │  transformer │                           Open CLIP "RN101::yfcc15m" model │
-│                                      RN50::cc12m │  text-to-image │       1024 │  transformer │                              Open CLIP "RN50::cc12m" model │
-│                                     RN50::openai │  text-to-image │       1024 │  transformer │                             Open CLIP "RN50::openai" model │
-│                            RN50-quickgelu::cc12m │  text-to-image │       1024 │  transformer │                    Open CLIP "RN50-quickgelu::cc12m" model │
-│                           RN50-quickgelu::openai │  text-to-image │       1024 │  transformer │                   Open CLIP "RN50-quickgelu::openai" model │
-│                          RN50-quickgelu::yfcc15m │  text-to-image │       1024 │  transformer │                  Open CLIP "RN50-quickgelu::yfcc15m" model │
-│                                  RN50x16::openai │  text-to-image │        768 │  transformer │                          Open CLIP "RN50x16::openai" model │
-│                                   RN50x4::openai │  text-to-image │        640 │  transformer │                           Open CLIP "RN50x4::openai" model │
-│                                  RN50x64::openai │  text-to-image │       1024 │  transformer │                          Open CLIP "RN50x64::openai" model │
-│                                    RN50::yfcc15m │  text-to-image │       1024 │  transformer │                            Open CLIP "RN50::yfcc15m" model │
-│                          ViT-B-16::laion400m_e31 │  text-to-image │        512 │  transformer │                  Open CLIP "ViT-B-16::laion400m_e31" model │
-│                          ViT-B-16::laion400m_e32 │  text-to-image │        512 │  transformer │                  Open CLIP "ViT-B-16::laion400m_e32" model │
-│                                 ViT-B-16::openai │  text-to-image │        512 │  transformer │                         Open CLIP "ViT-B-16::openai" model │
-│                 ViT-B-16-plus-240::laion400m_e31 │  text-to-image │        640 │  transformer │         Open CLIP "ViT-B-16-plus-240::laion400m_e31" model │
-│                 ViT-B-16-plus-240::laion400m_e32 │  text-to-image │        640 │  transformer │         Open CLIP "ViT-B-16-plus-240::laion400m_e32" model │
-│                            ViT-B-32::laion2b_e16 │  text-to-image │        512 │  transformer │                    Open CLIP "ViT-B-32::laion2b_e16" model │
-│                          ViT-B-32::laion400m_e31 │  text-to-image │        512 │  transformer │                  Open CLIP "ViT-B-32::laion400m_e31" model │
-│                          ViT-B-32::laion400m_e32 │  text-to-image │        512 │  transformer │                  Open CLIP "ViT-B-32::laion400m_e32" model │
-│                                 ViT-B-32::openai │  text-to-image │        512 │  transformer │                         Open CLIP "ViT-B-32::openai" model │
-│                ViT-B-32-quickgelu::laion400m_e31 │  text-to-image │        512 │  transformer │        Open CLIP "ViT-B-32-quickgelu::laion400m_e31" model │
-│                ViT-B-32-quickgelu::laion400m_e32 │  text-to-image │        512 │  transformer │        Open CLIP "ViT-B-32-quickgelu::laion400m_e32" model │
-│                       ViT-B-32-quickgelu::openai │  text-to-image │        512 │  transformer │               Open CLIP "ViT-B-32-quickgelu::openai" model │
-│                             ViT-L-14-336::openai │  text-to-image │        768 │  transformer │                     Open CLIP "ViT-L-14-336::openai" model │
-│                                 ViT-L-14::openai │  text-to-image │        768 │  transformer │                         Open CLIP "ViT-L-14::openai" model │
-│                                        resnet152 │ image-to-image │       2048 │          cnn │                          ResNet152 pre-trained on ImageNet │
-│                                         resnet50 │ image-to-image │       2048 │          cnn │                           ResNet50 pre-trained on ImageNet │
-│ sentence-transformers/msmarco-distilbert-base-v3 │   text-to-text │        768 │  transformer │                    Pretrained BERT, fine-tuned on MS Marco │
-└──────────────────────────────────────────────────┴────────────────┴────────────┴──────────────┴───────────────────────────────────────────────────────────
+import finetuner
 
+finetuner.describe_models(task='text-to-text')
 ```
+````
+````{tab} image-to-image
+```bash
+import finetuner
+
+finetuner.describe_models(task='image-to-image')
+```
+````
+````{tab} text-to-image
+```bash
+import finetuner
+
+finetuner.describe_models(task='text-to-image')
+```
+````
+
 + ResNets are suitable for image-to-image search tasks with high performance requirements, where `resnet152` is bigger and requires higher computational resources than `resnet50`.
 + EfficientNets are suitable for image-to-image search tasks with low training and inference times. The model is more light-weighted than ResNet. Here, `efficientnet_b4` is the bigger and more complex model.
 + CLIP is the one for text-to-image search, where the images do not need to have any text descriptors.

--- a/docs/walkthrough/run-job.md
+++ b/docs/walkthrough/run-job.md
@@ -127,8 +127,8 @@ The example below shows how to apply hard-negative mining:
 run = finetuner.fit(
     ...,
     loss='TripleMarginLoss',
-+    miner='TripletMarginMiner',
-+    miner_options={'margin': 0.3, 'type_of_triplets': 'hard'}
++   miner='TripletMarginMiner',
++   miner_options={'margin': 0.3, 'type_of_triplets': 'hard'}
 )
 ```
 

--- a/docs/walkthrough/run-job.md
+++ b/docs/walkthrough/run-job.md
@@ -121,6 +121,24 @@ For instance, if you choose to train a model with the `TripleMarginLoss`, you ca
 While without this miner, all possible triples with an anchor, a positive, and a negative candidate are constructed, the miner reduces this set of triples.
 Usually, only triples with hard negatives are selected where the distance between the positive and the negative example is inside a margin of `0.2`.
 If you want to pass additional parameters to configure the miner, you can specify the `miner_options` parameter of the fit function.
-For example, you can modify the size of the margin to `0.3` by setting `miner_options={'margin': 0.3}'`.
+The example below shows how to apply hard-negative mining:
+
+```diff
+run = finetuner.fit(
+    ...,
+    loss='TripleMarginLoss',
++    miner='TripletMarginMiner',
++    miner_options={'margin': 0.3, 'type_of_triplets': 'hard'}
+)
+```
+
+The possible choices `type_of_triplets` are:
+
++ `all`: Use all triplets, identical to no mining.
++ `easy`: Use all easy triplets, all triplets that do not violate the margin.
++ `semihard`: Use semi-hard triplets, the negative is further from the anchor than the positive.
++ `hard`: Use hard triplets, the negative is closer to the anchor than the positive.
+
+Finetuner takes `TripleMarginLoss` as default loss function with no negative mining.
 A detailed description of the miners and their parameters is specified in the [PyTorch Metric Learning documentation](https://kevinmusgrave.github.io/pytorch-metric-learning/miners/).
 

--- a/finetuner/__init__.py
+++ b/finetuner/__init__.py
@@ -99,9 +99,15 @@ def list_model_options() -> Dict[str, List[Dict[str, Any]]]:
     }
 
 
-def describe_models() -> None:
-    """Describe available models in a table."""
-    print_model_table(model)
+def describe_models(task: Optional[str] = None) -> None:
+    """Describe available models in a table.
+
+    :param task: The task for the backbone model designed for, one of `text-to-text`,
+        `text-to-image`, `image-to-image`. If not provided, will print all backbone
+        models.
+
+    """
+    print_model_table(model, task=task)
 
 
 @login_required

--- a/finetuner/__init__.py
+++ b/finetuner/__init__.py
@@ -102,7 +102,7 @@ def list_model_options() -> Dict[str, List[Dict[str, Any]]]:
 def describe_models(task: Optional[str] = None) -> None:
     """Describe available models in a table.
 
-    :param task: The task for the backbone model designed for, one of `text-to-text`,
+    :param task: The task for the backbone model, one of `text-to-text`,
         `text-to-image`, `image-to-image`. If not provided, will print all backbone
         models.
 

--- a/finetuner/console.py
+++ b/finetuner/console.py
@@ -14,8 +14,10 @@ def print_model_table(model, task: Optional[str] = None):
     :param model: Module with model definitions
     :param task: The fine-tuning task, should be one of `text-to-text`,
     """
-
-    table = Table(title='Finetuner backbones')
+    title = 'Finetuner backbones'
+    if task:
+        title += f': {task}'
+    table = Table(title=title)
     header = model.get_header()
     model_descriptors = set()
 
@@ -27,7 +29,7 @@ def print_model_table(model, task: Optional[str] = None):
             row = model.get_row(_model_class)
             if task and row[1] != task:
                 continue
-            table.add_row(*model.get_row(_model_class))
+            table.add_row(*row)
             model_descriptors.add(_model_class.descriptor)
 
     console.print(table)

--- a/finetuner/console.py
+++ b/finetuner/console.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from rich.console import Console
 from rich.table import Table
 
@@ -6,10 +8,11 @@ from finetuner.model import list_model_classes
 console = Console()
 
 
-def print_model_table(model):
+def print_model_table(model, task: Optional[str] = None):
     """Prints a table of model descriptions.
 
     :param model: Module with model definitions
+    :param task: The fine-tuning task, should be one of `text-to-text`,
     """
 
     table = Table(title='Finetuner backbones')
@@ -21,6 +24,9 @@ def print_model_table(model):
 
     for _, _model_class in list_model_classes().items():
         if _model_class.descriptor not in model_descriptors:
+            row = model.get_row(_model_class)
+            if task and row[1] != task:
+                continue
             table.add_row(*model.get_row(_model_class))
             model_descriptors.add(_model_class.descriptor)
 


### PR DESCRIPTION
<!--- PR Description here --->

The current `describe_model` is a bit mess given so many backbones are supported. I added a parameter `task` to allow user filter backbone by task, Documentation should be more straightforward.

![B12CDDAB-0462-4E73-9475-A85E3518B9C5](https://user-images.githubusercontent.com/9794489/201454221-1d80bcd7-cfde-46db-b98b-15b8054d97f9.png)


---

- [ ] This PR references an open issue
- [x] I have added a line about this change to CHANGELOG