### PR TITLE
chore: align text-to-image notebook with markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Docs
 
+- Align text-to-image notebook with its corresponding markdown file. ([#621](https://github.com/jina-ai/finetuner/pull/621))
+
 
 ## [0.6.7] - 2022-11-25
 

--- a/docs/notebooks/text_to_image.ipynb
+++ b/docs/notebooks/text_to_image.ipynb
@@ -3,8 +3,7 @@
   "nbformat_minor": 0,
   "metadata": {
     "colab": {
-      "provenance": [],
-      "collapsed_sections": []
+      "provenance": []
     },
     "kernelspec": {
       "name": "python3",
@@ -65,9 +64,11 @@
       "source": [
         "## Data\n",
         "Our journey starts locally. We have to [prepare the data and push it to the Jina AI Cloud](https://finetuner.jina.ai/walkthrough/create-training-data/) and Finetuner will be able to get the dataset by its name. For this example,\n",
-        "we already prepared the data, and we'll provide the names of training and evaluation data (`fashion-train-data-clip` and `fashion-eval-data-clip`) directly to Finetuner.\n",
+        "we already prepared the data, and we'll provide the names of traning and evaluation data (`fashion-train-data-clip` and `fashion-eval-data-clip`) directly to Finetuner.\n",
+        "In addition, we also provide labeled queries and an index of labeled documents for evaluating the retrieval capabilities of the resulting fine-tuned model stored in the datasets `fashion-eval-data-queries` and `fashion-eval-data-index`.\n",
         "\n",
-        "```{admonition} \n",
+        "\n",
+        "```{admonition} Push data to the cloud\n",
         "We don't require you to push data to the Jina AI Cloud by yourself. Instead of a name, you can provide a `DocumentArray` and Finetuner will do the job for you.\n",
         "```"
       ],
@@ -94,6 +95,8 @@
       "source": [
         "train_data = DocumentArray.pull('fashion-train-data-clip', show_progress=True)\n",
         "eval_data = DocumentArray.pull('fashion-eval-data-clip', show_progress=True)\n",
+        "query_data = DocumentArray.pull('fashion-eval-data-queries', show_progress=True)\n",
+        "index_data = DocumentArray.pull('fashion-eval-data-index', show_progress=True)\n",
         "\n",
         "train_data.summary()"
       ],
@@ -129,7 +132,7 @@
     {
       "cell_type": "code",
       "source": [
-        "import finetuner\n",
+        "from finetuner.callback import EvaluationCallback\n",
         "\n",
         "run = finetuner.fit(\n",
         "    model='openai/clip-vit-base-patch32',\n",
@@ -139,6 +142,14 @@
         "    learning_rate= 1e-7,\n",
         "    loss='CLIPLoss',\n",
         "    device='cuda',\n",
+        "    callbacks=[\n",
+        "        EvaluationCallback(\n",
+        "            model='clip-text',\n",
+        "            index_model='clip-vision',\n",
+        "            query_data='fashion-eval-data-queries',\n",
+        "            index_data='fashion-eval-data-index',\n",
+        "        )\n",
+        "    ],\n",
         ")"
       ],
       "metadata": {
@@ -154,7 +165,8 @@
         "\n",
         "* We start with providing `model`, names of training and evaluation data.\n",
         "* We also provide some hyper-parameters such as number of `epochs` and a `learning_rate`.\n",
-        "* We use `CLIPLoss` to optimize the CLIP model."
+        "* We use `CLIPLoss` to optimize the CLIP model.\n",
+        "* We use an evaluation callback, which uses the `'clip-text'` model for encoding the text queries and the `'clip-vision'` model for encoding the images in `'fashion-eval-data-index'`.\n"
       ],
       "metadata": {
         "id": "QPDmFdubxzUE"
@@ -206,38 +218,20 @@
       "cell_type": "markdown",
       "source": [
         "## Evaluating\n",
-        "Currently, we don't have a user-friendly way to get evaluation metrics from the {class}`~finetuner.callback.EvaluationCallback` we initialized previously.\n",
+        "\n",
+        "Our `EvaluationCallback` during fine-tuning ensures that after each epoch, an evaluation of our model is run. We can access the results of the last evaluation in the logs as follows `print(run.logs())`:\n",
         "\n",
         "```bash\n",
-        "           INFO     Done ✨                                                                              __main__.py:219\n",
-        "           INFO     Saving fine-tuned models ...                                                         __main__.py:222\n",
-        "           INFO     Saving model 'model' in /usr/src/app/tuned-models/model ...                          __main__.py:233\n",
-        "           INFO     Pushing saved model to Jina AI Cloud ...                                                    __main__.py:240\n",
-        "[10:38:14] INFO     Pushed model artifact ID: '62a1af491597c219f6a330fe'                                 __main__.py:246\n",
-        "           INFO     Finished 🚀                                                                          __main__.py:248\n",
-        "```\n",
-        "\n",
-        "```{admonition} Evaluation of CLIP\n",
-        "\n",
-        "In this example, we did not plug-in an `EvaluationCallback` since the callback can evaluate one model at one time.\n",
-        "In most cases, we want to evaluate two models: i.e. use `CLIPTextEncoder` to encode textual Documents as `query_data` while use `CLIPImageEncoder` to encode image Documents as `index_data`.\n",
-        "Then use the textual Documents to search image Documents.\n",
-        "\n",
-        "We have done the evaulation for you in the table below.\n",
-        "```\n",
-        "\n",
-        "\n",
-        "|                   | Before Finetuning | After Finetuning |\n",
-        "|:------------------|---------:|---------:|\n",
-        "| average_precision | 0.47219  | 0.532773 |\n",
-        "| dcg_at_k          | 2.25565  | 2.70725  |\n",
-        "| f1_score_at_k     | 0.296816 | 0.353499 |\n",
-        "| hit_at_k          | 0.94028  | 0.942821 |\n",
-        "| ndcg_at_k         | 0.613387 | 0.673644 |\n",
-        "| precision_at_k    | 0.240407 | 0.285324 |\n",
-        "| r_precision       | 0.364697 | 0.409577 |\n",
-        "| recall_at_k       | 0.472681 | 0.564168 |\n",
-        "| reciprocal_rank   | 0.575481 | 0.67571  |"
+        "  Training [5/5] ━━━━ 195/195 0:00… 0:0… • loss: 2.419 • val_loss: 2.803\n",
+        "[13:32:41] INFO     Done ✨                              __main__.py:195\n",
+        "           DEBUG    Finetuning took 0 days, 0 hours 5 minutes and 30 seconds\n",
+        "           DEBUG    Metric: 'clip-text-to-clip-vision_precision_at_k' Value: 0.28532                                                   \n",
+        "           DEBUG    Metric: 'clip-text-to-clip-vision_hit_at_k' Value: 0.94282                                            \n",
+        "           DEBUG    Metric: 'clip-text-to-clip-vision_average_precision' Value: 0.53372                             \n",
+        "           DEBUG    Metric: 'clip-text-to-clip-vision_reciprocal_rank' Value: 0.67706                               \n",
+        "           DEBUG    Metric: 'clip-text-to-clip-vision_dcg_at_k' Value: 2.71247                                      \n",
+        "...\n",
+        "```\n"
       ],
       "metadata": {
         "id": "Xeq_aVRxyqlW"


### PR DESCRIPTION
After the release the text-to-image notebook is now running. This PR just updates the notebook to be coherent with the markdown file.

---

- [ ] This PR references an open issue
- [x] I have added a line about this change to CHANGELOG