### PR TITLE
Fix build encoding dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Correctly infer the type of models created using `get_model` in the `build_encoding_dataset` function. )[#623](https://github.com/jina-ai/finetuner/pull/623))
+
 ### Docs
 
 - Align text-to-image notebook with its corresponding markdown file. ([#621](https://github.com/jina-ai/finetuner/pull/621))

--- a/finetuner/data.py
+++ b/finetuner/data.py
@@ -69,7 +69,10 @@ def build_encoding_dataset(model: 'InferenceEngine', data: List[str]) -> Documen
     """
     modalities = model._metadata['preprocess_types']
     if model._select_model:
-        task = modalities[model._select_model]
+        if model._select_model == 'clip-text':
+            task = 'text'
+        else:
+            task = 'image'
     elif list(modalities)[0] == ['features']:
         raise ValueError('MLP model does not support values from a list.')
     else:


### PR DESCRIPTION
Currently, attempting to encode data from a list using a CLIP model made using `get_model` will result in an error, this pr prevents that by changing the method of determining the inferring the modality of the model

---

- [ ] This PR references an open issue
- [x] I have added a line about this change to CHANGELOG