### PR TITLE
docs: modify hints to use blobs instead of tensor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Align text-to-image notebook with its corresponding markdown file. ([#621](https://github.com/jina-ai/finetuner/pull/621))
 
+- Change hint in notebooks to use `load_uri_to_blob` instead of `load_uri_to_image_tensor`. ([#625](https://github.com/jina-ai/finetuner/pull/625))
+
 
 ## [0.6.7] - 2022-11-25
 

--- a/docs/notebooks/image_to_image.ipynb
+++ b/docs/notebooks/image_to_image.ipynb
@@ -71,7 +71,7 @@
         "\n",
         "```{important} \n",
         "We don't require you to push data to the Jina AI Cloud by yourself. Instead of a name, you can provide a `DocumentArray` and Finetuner will do the job for you.\n",
-        "When working with documents where images are stored locally, please call `doc.load_uri_to_blob` to reduce network transmission and speed up training.\n",
+        "When working with documents where images are stored locally, please call `doc.load_uri_to_blob()` to reduce network transmission and speed up training.\n",
         "```"
       ],
       "metadata": {

--- a/docs/notebooks/image_to_image.ipynb
+++ b/docs/notebooks/image_to_image.ipynb
@@ -3,8 +3,7 @@
   "nbformat_minor": 0,
   "metadata": {
     "colab": {
-      "provenance": [],
-      "collapsed_sections": []
+      "provenance": []
     },
     "kernelspec": {
       "name": "python3",
@@ -72,10 +71,7 @@
         "\n",
         "```{important} \n",
         "We don't require you to push data to the Jina AI Cloud by yourself. Instead of a name, you can provide a `DocumentArray` and Finetuner will do the job for you.\n",
-        "```\n",
-        "\n",
-        "```{important}\n",
-        "When working with Document where images are stored locally, please call `doc.load_uri_to_image_tensor(width=224, height=224)` or another image shape to reduce network transmission and speed up training.\n",
+        "When working with documents where images are stored locally, please call `doc.load_uri_to_blob` to reduce network transmission and speed up training.\n",
         "```"
       ],
       "metadata": {

--- a/docs/notebooks/image_to_image.md
+++ b/docs/notebooks/image_to_image.md
@@ -48,7 +48,7 @@ we already prepared the data, and we'll provide the names of training data (`tll
 
 ```{important} 
 We don't require you to push data to the Jina AI Cloud by yourself. Instead of a name, you can provide a `DocumentArray` and Finetuner will do the job for you.
-When working with documents where images are stored locally, please call `doc.load_uri_to_blob` to reduce network transmission and speed up training.
+When working with documents where images are stored locally, please call `doc.load_uri_to_blob()` to reduce network transmission and speed up training.
 ```
 <!-- #endregion -->
 

--- a/docs/notebooks/image_to_image.md
+++ b/docs/notebooks/image_to_image.md
@@ -48,10 +48,7 @@ we already prepared the data, and we'll provide the names of training data (`tll
 
 ```{important} 
 We don't require you to push data to the Jina AI Cloud by yourself. Instead of a name, you can provide a `DocumentArray` and Finetuner will do the job for you.
-```
-
-```{important}
-When working with Document where images are stored locally, please call `doc.load_uri_to_image_tensor(width=224, height=224)` or another image shape to reduce network transmission and speed up training.
+When working with documents where images are stored locally, please call `doc.load_uri_to_blob` to reduce network transmission and speed up training.
 ```
 <!-- #endregion -->
 

--- a/docs/notebooks/text_to_image.ipynb
+++ b/docs/notebooks/text_to_image.ipynb
@@ -70,6 +70,7 @@
         "\n",
         "```{admonition} Push data to the cloud\n",
         "We don't require you to push data to the Jina AI Cloud by yourself. Instead of a name, you can provide a `DocumentArray` and Finetuner will do the job for you.\n",
+        "When working with documents where images are stored locally, please call `doc.load_uri_to_blob` to reduce network transmission and speed up training.\n",
         "```"
       ],
       "metadata": {
@@ -356,15 +357,6 @@
       "metadata": {
         "id": "LHyMm_M1zxdt"
       }
-    },
-    {
-      "cell_type": "code",
-      "source": [],
-      "metadata": {
-        "id": "DYmj0nozyVCL"
-      },
-      "execution_count": null,
-      "outputs": []
     }
   ]
 }

--- a/docs/notebooks/text_to_image.ipynb
+++ b/docs/notebooks/text_to_image.ipynb
@@ -70,7 +70,7 @@
         "\n",
         "```{admonition} Push data to the cloud\n",
         "We don't require you to push data to the Jina AI Cloud by yourself. Instead of a name, you can provide a `DocumentArray` and Finetuner will do the job for you.\n",
-        "When working with documents where images are stored locally, please call `doc.load_uri_to_blob` to reduce network transmission and speed up training.\n",
+        "When working with documents where images are stored locally, please call `doc.load_uri_to_blob()` to reduce network transmission and speed up training.\n",
         "```"
       ],
       "metadata": {

--- a/docs/notebooks/text_to_image.md
+++ b/docs/notebooks/text_to_image.md
@@ -47,6 +47,7 @@ In addition, we also provide labeled queries and an index of labeled documents f
 
 ```{admonition} Push data to the cloud
 We don't require you to push data to the Jina AI Cloud by yourself. Instead of a name, you can provide a `DocumentArray` and Finetuner will do the job for you.
+When working with documents where images are stored locally, please call `doc.load_uri_to_blob` to reduce network transmission and speed up training.
 ```
 <!-- #endregion -->
 
@@ -240,7 +241,3 @@ The value you set to `alpha` should be greater equal than 0 and less equal than 
 
 That's it! Check out [clip-as-service](https://clip-as-service.jina.ai/user-guides/finetuner/?highlight=finetuner#fine-tune-models) to learn how to plug-in a fine-tuned CLIP model to our CLIP specific service.
 <!-- #endregion -->
-
-```python id="DYmj0nozyVCL"
-
-```

--- a/docs/notebooks/text_to_image.md
+++ b/docs/notebooks/text_to_image.md
@@ -47,7 +47,7 @@ In addition, we also provide labeled queries and an index of labeled documents f
 
 ```{admonition} Push data to the cloud
 We don't require you to push data to the Jina AI Cloud by yourself. Instead of a name, you can provide a `DocumentArray` and Finetuner will do the job for you.
-When working with documents where images are stored locally, please call `doc.load_uri_to_blob` to reduce network transmission and speed up training.
+When working with documents where images are stored locally, please call `doc.load_uri_to_blob()` to reduce network transmission and speed up training.
 ```
 <!-- #endregion -->
 


### PR DESCRIPTION
This PR modifies the hints in notebooks to load images to blobs instead of tensors.
---

- [ ] This PR references an open issue
- [x] I have added a line about this change to CHANGELOG