### PR TITLE
ci: add remote-ci for core

### DIFF
--- a/.github/workflows/remote-ci.yml
+++ b/.github/workflows/remote-ci.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           repository: jina-ai/finetuner-core
           ref: main
-          token: ${{ secrets.JINA_DEV_BOT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install requirements
         run: |
           make install package=style
@@ -49,7 +49,7 @@ jobs:
         with:
           repository: jina-ai/finetuner-core
           ref: main
-          token: ${{ secrets.JINA_DEV_BOT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install requirements
         run: make install package=style
       - name: check black
@@ -67,7 +67,7 @@ jobs:
         with:
           repository: jina-ai/finetuner-core
           ref: main
-          token: ${{ secrets.JINA_DEV_BOT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install requirements
         run: make install package=style
       - name: check isort

--- a/.github/workflows/remote-ci.yml
+++ b/.github/workflows/remote-ci.yml
@@ -7,7 +7,9 @@ on:
         description: Pass the finetuner-core branch
         required: true
         default: main
-
+  repository_dispatch:
+    types: [triggered_from_core]
+    
 env:
   JINA_AUTH_TOKEN: ${{ secrets.JINA_AUTH_TOKEN }}
 

--- a/.github/workflows/remote-ci.yml
+++ b/.github/workflows/remote-ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: jina-ai/finetuner-core
-          ref: main
+          ref: ${{ github.event.client_payload.branch  }}
           token: ${{ secrets.FINETUNER_CORE_REPO }}
       - name: Install requirements
         run: |
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: jina-ai/finetuner-core
-          ref: main
+          ref: ${{ github.event.client_payload.branch  }}
           token: ${{ secrets.FINETUNER_CORE_REPO }}
       - name: Install requirements
         run: make install package=style
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: jina-ai/finetuner-core
-          ref: main
+          ref: ${{ github.event.client_payload.branch  }}
           token: ${{ secrets.FINETUNER_CORE_REPO }}
       - name: Install requirements
         run: make install package=style
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: jina-ai/finetuner-core
-          ref: main
+          ref: ${{ github.event.client_payload.branch  }}
           token: ${{ secrets.FINETUNER_CORE_REPO }}
       - name: Gather core test paths
         id: gather-core-tests
@@ -110,7 +110,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: jina-ai/finetuner-core
-          ref: main
+          ref: ${{ github.event.client_payload.branch  }}
           token: ${{ secrets.FINETUNER_CORE_REPO }}
       - name: Prepare enviroment
         run: |
@@ -148,7 +148,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: jina-ai/finetuner-core
-          ref: main
+          ref: ${{ github.event.client_payload.branch  }}
           token: ${{ secrets.FINETUNER_CORE_REPO }}
       - name: Prepare enviroment
         run: |
@@ -182,7 +182,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: jina-ai/finetuner-core
-          ref: main
+          ref: ${{ github.event.client_payload.branch  }}
           token: ${{ secrets.FINETUNER_CORE_REPO }}
       - name: Prepare enviroment
         run: |

--- a/.github/workflows/remote-ci.yml
+++ b/.github/workflows/remote-ci.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           repository: jina-ai/finetuner-core
           ref: main
-          token: ${{ secrets.JINA_DEV_BOT }}
+          token: ${{ secrets.FINETUNER_CORE_REPO }}
       - name: Install requirements
         run: |
           make install package=style
@@ -45,7 +45,7 @@ jobs:
         with:
           repository: jina-ai/finetuner-core
           ref: main
-          token: ${{ secrets.JINA_DEV_BOT }}
+          token: ${{ secrets.FINETUNER_CORE_REPO }}
       - name: Install requirements
         run: make install package=style
       - name: check black
@@ -63,7 +63,7 @@ jobs:
         with:
           repository: jina-ai/finetuner-core
           ref: main
-          token: ${{ secrets.JINA_DEV_BOT }}
+          token: ${{ secrets.FINETUNER_CORE_REPO }}
       - name: Install requirements
         run: make install package=style
       - name: check isort

--- a/.github/workflows/remote-ci.yml
+++ b/.github/workflows/remote-ci.yml
@@ -3,15 +3,8 @@ name: Core-CI
 on:
   pull_request:
 
-
-# on:
-#   workflow_dispatch:
-#     inputs:
-#       branch:
-#         description: Pass the finetuner-core branch
-#         required: true
-#         default: main
-
+env:
+  JINA_AUTH_TOKEN: ${{ secrets.JINA_AUTH_TOKEN }}
 
 jobs:
   style-flake:
@@ -68,3 +61,155 @@ jobs:
         run: make install package=style
       - name: check isort
         run: make isort-check
+
+  prep-testbed:
+    runs-on: ubuntu-latest
+    needs: [style-flake, style-black, style-isort]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install jq
+        run: sudo apt-get install jq
+      - uses: actions/checkout@v3
+        with:
+          repository: jina-ai/finetuner-core
+          ref: main
+          token: ${{ secrets.FINETUNER_CORE_REPO }}
+      - name: Gather core test paths
+        id: gather-core-tests
+        run: |
+          core_test_paths=$( find 'tests' -name 'test_*.py' | xargs grep -l 'def test_' | xargs dirname | sort -u | jq -R . | jq -cs . )
+          echo "::set-output name=core-tests-matrix::$core_test_paths"
+      - name: Gather CUDA test paths
+        id: gather-cuda-tests
+        run: |
+          cuda_test_paths=$( find 'tests' -name 'test_*.py' | xargs grep -l 'def test_' | xargs grep -l 'pytest.mark.gpu' | xargs dirname | sort -u | jq -R . | jq -cs . )
+          echo "::set-output name=cuda-tests-matrix::$cuda_test_paths"
+      - name: Generate UUID for the artifact of the current run
+        id: generate-artifact-id
+        run: |
+          echo "::set-output name=artifact-id::$(uuidgen)"
+    outputs:
+      artifact-id: ${{ steps.generate-artifact-id.outputs.artifact-id }}
+      core-tests-matrix: ${{ steps.gather-core-tests.outputs.core-tests-matrix }}
+      cuda-tests-matrix: ${{ steps.gather-cuda-tests.outputs.cuda-tests-matrix }}
+
+  test-core:
+    needs: prep-testbed
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tests-path: ${{fromJson(needs.prep-testbed.outputs.core-tests-matrix)}}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - uses: actions/checkout@v3
+        with:
+          repository: jina-ai/finetuner-core
+          ref: main
+          token: ${{ secrets.FINETUNER_CORE_REPO }}
+      - name: Prepare enviroment
+        run: |
+          python -m pip install --upgrade pip
+          make install package=cicd.cpu
+          make prepare-executor
+      - name: Test
+        id: test
+        run: |
+          make test TESTS_PATH=${{ matrix.tests-path }}/test_\*.py
+          COVERAGE_NAME=.coverage.core.$( echo ${{ matrix.tests-path }} | tr "/" . )
+          echo "COVERAGE_NAME=$COVERAGE_NAME" >> $GITHUB_ENV
+          mv .coverage $COVERAGE_NAME
+        timeout-minutes: 30
+      - name: Upload coverage
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-${{ needs.prep-testbed.outputs.artifact-id }}
+          path: ${{ env.COVERAGE_NAME }}
+          retention-days: 1
+
+  test-cuda:
+    needs: prep-testbed
+    runs-on: [self-hosted, x64, gpu, linux]
+    strategy:
+      fail-fast: false
+      matrix:
+        tests-path: ${{fromJson(needs.prep-testbed.outputs.cuda-tests-matrix)}}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - uses: actions/checkout@v3
+        with:
+          repository: jina-ai/finetuner-core
+          ref: main
+          token: ${{ secrets.FINETUNER_CORE_REPO }}
+      - name: Prepare enviroment
+        run: |
+          python -m pip install --upgrade pip
+          make install package=cicd.cuda
+          make prepare-executor
+      - name: Test
+        id: test
+        run: |
+          make test-cuda TESTS_PATH=${{ matrix.tests-path }}/test_\*.py
+          COVERAGE_NAME=.coverage.cuda.$( echo ${{ matrix.tests-path }} | tr "/" . )
+          echo "COVERAGE_NAME=$COVERAGE_NAME" >> $GITHUB_ENV
+          mv .coverage $COVERAGE_NAME
+        timeout-minutes: 30
+      - name: Upload coverage
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-${{ needs.prep-testbed.outputs.artifact-id }}
+          path: ${{ env.COVERAGE_NAME }}
+          retention-days: 1
+
+  get-coverage:
+    needs: [prep-testbed, test-core, test-cuda]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - uses: actions/checkout@v3
+        with:
+          repository: jina-ai/finetuner-core
+          ref: main
+          token: ${{ secrets.FINETUNER_CORE_REPO }}
+      - name: Prepare enviroment
+        run: |
+          python -m pip install --upgrade pip pytest pytest-cov
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: coverage-${{ needs.prep-testbed.outputs.artifact-id }}
+      - name: Combine coverages
+        run: |
+          coverage combine -a .coverage*
+          coverage xml
+      - name: Comment with coverage report
+        uses: MishaKav/pytest-coverage-comment@main
+        with:
+          pytest-xml-coverage-path: ./coverage.xml
+          title: Finetuner Coverage Report
+
+  # just for blocking the merge until all parallel core-test are successful
+  success-tests:
+    needs: [get-coverage, test-core, test-cuda]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: technote-space/workflow-conclusion-action@v2
+      - name: Check Failure
+        if: env.WORKFLOW_CONCLUSION == 'failure'
+        run: exit 1
+      - name: Success
+        if: ${{ success() }}
+        run: echo "All Done"

--- a/.github/workflows/remote-ci.yml
+++ b/.github/workflows/remote-ci.yml
@@ -1,12 +1,6 @@
 name: Core-CI
 
 on:
-  workflow_dispatch:
-    inputs:
-      branch:
-        description: Pass the finetuner-core branch
-        required: true
-        default: main
   repository_dispatch:
     types: [triggered_from_core]
     

--- a/.github/workflows/remote-ci.yml
+++ b/.github/workflows/remote-ci.yml
@@ -11,11 +11,7 @@ on:
 #         description: Pass the finetuner-core branch
 #         required: true
 #         default: main
-#       only_api_changed:
-#         description: Check the box only if API related code was changed
-#         type: boolean
-#         default: false
-#         required: false
+
 
 jobs:
   style-flake:
@@ -30,7 +26,7 @@ jobs:
         with:
           repository: jina-ai/finetuner-core
           ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.JINA_DEV_BOT }}
       - name: Install requirements
         run: |
           make install package=style
@@ -49,7 +45,7 @@ jobs:
         with:
           repository: jina-ai/finetuner-core
           ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.JINA_DEV_BOT }}
       - name: Install requirements
         run: make install package=style
       - name: check black
@@ -67,7 +63,7 @@ jobs:
         with:
           repository: jina-ai/finetuner-core
           ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.JINA_DEV_BOT }}
       - name: Install requirements
         run: make install package=style
       - name: check isort

--- a/.github/workflows/remote-ci.yml
+++ b/.github/workflows/remote-ci.yml
@@ -1,17 +1,21 @@
 name: Core-CI
 
 on:
-  workflow_dispatch:
-    inputs:
-      branch:
-        description: Pass the finetuner-core branch
-        required: true
-        default: main
-      only_api_changed:
-        description: Check the box only if API related code was changed
-        type: boolean
-        default: false
-        required: false
+  pull_request:
+
+
+# on:
+#   workflow_dispatch:
+#     inputs:
+#       branch:
+#         description: Pass the finetuner-core branch
+#         required: true
+#         default: main
+#       only_api_changed:
+#         description: Check the box only if API related code was changed
+#         type: boolean
+#         default: false
+#         required: false
 
 jobs:
   style-flake:
@@ -25,7 +29,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: jina-ai/finetuner-core
-          ref: ${{ github.event.inputs.branch }}
+          ref: main
           token: ${{ secrets.JINA_DEV_BOT }}
       - name: Install requirements
         run: |
@@ -44,7 +48,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: jina-ai/finetuner-core
-          ref: ${{ github.event.inputs.branch }}
+          ref: main
           token: ${{ secrets.JINA_DEV_BOT }}
       - name: Install requirements
         run: make install package=style
@@ -62,7 +66,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: jina-ai/finetuner-core
-          ref: ${{ github.event.inputs.branch }}
+          ref: main
           token: ${{ secrets.JINA_DEV_BOT }}
       - name: Install requirements
         run: make install package=style

--- a/.github/workflows/remote-ci.yml
+++ b/.github/workflows/remote-ci.yml
@@ -1,7 +1,12 @@
 name: Core-CI
 
 on:
-  pull_request:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Pass the finetuner-core branch
+        required: true
+        default: main
 
 env:
   JINA_AUTH_TOKEN: ${{ secrets.JINA_AUTH_TOKEN }}

--- a/.github/workflows/remote-ci.yml
+++ b/.github/workflows/remote-ci.yml
@@ -1,0 +1,70 @@
+name: Core-CI
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Pass the finetuner-core branch
+        required: true
+        default: main
+      only_api_changed:
+        description: Check the box only if API related code was changed
+        type: boolean
+        default: false
+        required: false
+
+jobs:
+  style-flake:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - uses: actions/checkout@v3
+        with:
+          repository: jina-ai/finetuner-core
+          ref: ${{ github.event.inputs.branch }}
+          token: ${{ secrets.JINA_DEV_BOT }}
+      - name: Install requirements
+        run: |
+          make install package=style
+      - name: Lint with flake8
+        run: make flake
+
+  style-black:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - uses: actions/checkout@v3
+        with:
+          repository: jina-ai/finetuner-core
+          ref: ${{ github.event.inputs.branch }}
+          token: ${{ secrets.JINA_DEV_BOT }}
+      - name: Install requirements
+        run: make install package=style
+      - name: check black
+        run: make black-check
+
+  style-isort:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - uses: actions/checkout@v3
+        with:
+          repository: jina-ai/finetuner-core
+          ref: ${{ github.event.inputs.branch }}
+          token: ${{ secrets.JINA_DEV_BOT }}
+      - name: Install requirements
+        run: make install package=style
+      - name: check isort
+        run: make isort-check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `val_split` parameter to `fit` function. ([#624](https://github.com/jina-ai/finetuner/pull/624))
 
+- Add `core-ci` workflow to remotely run the ci of finetuner-core. ([#628](https://github.com/jina-ai/finetuner/pull/628))
+
 ### Removed
 
 ### Changed


### PR DESCRIPTION
This pr adds a CI job that can be manually triggered and will run tests on finetuner-core

currently, the core-ci workflow can be triggered in two ways:
A workflow dispatch, in which a user can manually trigger the workflow from the actions tab of this repo
A repository dispatch, in which the another repository (expected to be core) can remotely trigger the workflow.
Both of these methods only work when the workflow exists on the master branch, meaning that this pr needs to be tested before it can be merged

---

- [x] This PR references an open issue
- [x] I have added a line about this change to CHANGELOG