### PR TITLE
fix: adjust list experiments endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Adjust Finetuner based on API changes for Jina AI Cloud. ([#636](https://github.com/jina-ai/finetuner/pull/636))
+
+- Change default `experiment_name` from current working dir to `default`. ([#636](https://github.com/jina-ai/finetuner/pull/636))
+
 ### Fixed
 
 - Correctly infer the type of models created using `get_model` in the `build_encoding_dataset` function. )[#623](https://github.com/jina-ai/finetuner/pull/623))

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ build-sdist:
 
 # ---------------------------------------------------------------- Test related targets
 
-PYTEST_ARGS = --show-capture no --full-trace --verbose --cov finetuner/ --cov-report term-missing --cov-report html
+PYTEST_ARGS = --show-capture no --verbose --cov finetuner/ --cov-report term-missing --cov-report html
 
 ## Run tests
 test:

--- a/finetuner/__init__.py
+++ b/finetuner/__init__.py
@@ -322,9 +322,13 @@ def get_experiment(name: str) -> Experiment:
     return ft.get_experiment(name=name)
 
 
-def list_experiments() -> List[Experiment]:
-    """List every experiment."""
-    return ft.list_experiments()
+def list_experiments(size: int = 50) -> List[Experiment]:
+    """List every experiment.
+
+    :param size: The number of experiments to retrieve.
+    :return: A list of :class:`Experiment`.
+    """
+    return ft.list_experiments(size=size)
 
 
 def delete_experiment(name: str) -> Experiment:

--- a/finetuner/__init__.py
+++ b/finetuner/__init__.py
@@ -267,16 +267,16 @@ def get_run(run_name: str, experiment_name: Optional[str] = None) -> Run:
     return ft.get_run(run_name=run_name, experiment_name=experiment_name)
 
 
-def list_runs(experiment_name: Optional[str] = None) -> List[Run]:
+def list_runs(experiment_name: Optional[str] = None, size: int = 50) -> List[Run]:
     """List every run.
 
     If an experiment name is not specified, we'll list every run across all
     experiments.
 
     :param experiment_name: Optional name of the experiment.
-    :return: A list of `Run` objects.
+    :param size: Number of runs to retrieve.
     """
-    return ft.list_runs(experiment_name=experiment_name)
+    return ft.list_runs(experiment_name=experiment_name, size=size)
 
 
 def delete_run(run_name: str, experiment_name: Optional[str] = None) -> None:

--- a/finetuner/__init__.py
+++ b/finetuner/__init__.py
@@ -303,11 +303,11 @@ def delete_runs(experiment_name: Optional[str] = None) -> None:
     ft.delete_runs(experiment_name=experiment_name)
 
 
-def create_experiment(name: Optional[str] = None) -> Experiment:
+def create_experiment(name: str = 'default') -> Experiment:
     """Create an experiment.
 
-    :param name: Optional name of the experiment. If `None`,
-        the experiment is named after the current directory.
+    :param name: The name of the experiment. If not provided,
+        the experiment is named as `default`.
     :return: An `Experiment` object.
     """
     return ft.create_experiment(name=name)

--- a/finetuner/client/client.py
+++ b/finetuner/client/client.py
@@ -94,11 +94,14 @@ class FinetunerV1Client(_BaseClient):
         )
         return self._handle_request(url=url, method=GET)
 
-    def list_runs(self, experiment_name: Optional[str] = None) -> List[dict]:
+    def list_runs(
+        self, experiment_name: Optional[str] = None, size: int = 50
+    ) -> List[dict]:
         """List all created runs inside a given experiment.
 
         If no experiment is specified, list runs for all available experiments.
         :param experiment_name: The name of the experiment.
+        :param size: Number of runs to retrieve.
         :return: List of all runs.
         """
         if not experiment_name:
@@ -107,6 +110,8 @@ class FinetunerV1Client(_BaseClient):
             url = self._construct_url(
                 self._base_url, API_VERSION, EXPERIMENTS, experiment_name, RUNS
             )
+        if size:
+            url += f'?size={size}'
         return self._handle_request(url=url, method=GET)
 
     def delete_run(self, experiment_name: str, run_name: str) -> dict:

--- a/finetuner/client/client.py
+++ b/finetuner/client/client.py
@@ -59,9 +59,9 @@ class FinetunerV1Client(_BaseClient):
         :param size: The number of experiments to retrieve.
         :return: A list of :class:`Experiment`.
         """
+        params = {'size': size}
         url = self._construct_url(self._base_url, API_VERSION, EXPERIMENTS)
-        url += f'?size={size}'
-        return self._handle_request(url=url, method=GET)
+        return self._handle_request(url=url, method=GET, params=params)
 
     def delete_experiment(self, name: str) -> dict:
         """Delete an experiment given its name.
@@ -110,9 +110,8 @@ class FinetunerV1Client(_BaseClient):
             url = self._construct_url(
                 self._base_url, API_VERSION, EXPERIMENTS, experiment_name, RUNS
             )
-        if size:
-            url += f'?size={size}'
-        return self._handle_request(url=url, method=GET)
+        params = {'size': size}
+        return self._handle_request(url=url, method=GET, params=params)
 
     def delete_run(self, experiment_name: str, run_name: str) -> dict:
         """Delete a run by its name and experiment.

--- a/finetuner/client/client.py
+++ b/finetuner/client/client.py
@@ -53,12 +53,14 @@ class FinetunerV1Client(_BaseClient):
         url = self._construct_url(self._base_url, API_VERSION, EXPERIMENTS, name)
         return self._handle_request(url=url, method=GET)
 
-    def list_experiments(self) -> List[dict]:
-        """List all available experiments.
+    def list_experiments(self, size: int = 50) -> List[dict]:
+        """List every experiment.
 
-        :return: List of all experiments.
+        :param size: The number of experiments to retrieve.
+        :return: A list of :class:`Experiment`.
         """
         url = self._construct_url(self._base_url, API_VERSION, EXPERIMENTS)
+        url += f'?size={size}'
         return self._handle_request(url=url, method=GET)
 
     def delete_experiment(self, name: str) -> dict:

--- a/finetuner/client/client.py
+++ b/finetuner/client/client.py
@@ -102,18 +102,12 @@ class FinetunerV1Client(_BaseClient):
         :return: List of all runs.
         """
         if not experiment_name:
-            target_experiments = [
-                experiment[NAME] for experiment in self.list_experiments()
-            ]
+            url = self._construct_url(self._base_url, API_VERSION, RUNS, RUNS)
         else:
-            target_experiments = [experiment_name]
-        response = []
-        for experiment_name in target_experiments:
             url = self._construct_url(
                 self._base_url, API_VERSION, EXPERIMENTS, experiment_name, RUNS
             )
-            response.extend(self._handle_request(url=url, method=GET))
-        return response
+        return self._handle_request(url=url, method=GET)
 
     def delete_run(self, experiment_name: str, run_name: str) -> dict:
         """Delete a run by its name and experiment.

--- a/finetuner/client/client.py
+++ b/finetuner/client/client.py
@@ -32,7 +32,9 @@ class FinetunerV1Client(_BaseClient):
 
     """ Experiment API """
 
-    def create_experiment(self, name: str, description: Optional[str] = '') -> dict:
+    def create_experiment(
+        self, name: str = 'default', description: Optional[str] = ''
+    ) -> dict:
         """Create a new experiment.
 
         :param name: The name of the experiment.

--- a/finetuner/experiment.py
+++ b/finetuner/experiment.py
@@ -78,12 +78,12 @@ class Experiment:
         :param name: Name of the run.
         :return: A `Run` object.
         """
-        run_info = self._client.get_run(experiment_name=self._name, run_name=name)
+        run = self._client.get_run(experiment_name=self._name, run_name=name)
         run = Run(
-            name=run_info[NAME],
-            config=run_info[CONFIG],
-            created_at=run_info[CREATED_AT],
-            description=run_info[DESCRIPTION],
+            name=run[NAME],
+            config=run[CONFIG],
+            created_at=run[CREATED_AT],
+            description=run[DESCRIPTION],
             experiment_name=self._name,
             client=self._client,
         )
@@ -95,19 +95,17 @@ class Experiment:
         :param size: Number of runs to retrieve.
         :return: List of `Run` objects.
         """
-        run_infos = self._client.list_runs(experiment_name=self._name, size=size)[
-            'items'
-        ]
+        runs = self._client.list_runs(experiment_name=self._name, size=size)['items']
         return [
             Run(
-                name=run_info[NAME],
-                config=run_info[CONFIG],
-                created_at=run_info[CREATED_AT],
-                description=run_info[DESCRIPTION],
+                name=run[NAME],
+                config=run[CONFIG],
+                created_at=run[CREATED_AT],
+                description=run[DESCRIPTION],
                 experiment_name=self._name,
                 client=self._client,
             )
-            for run_info in run_infos
+            for run in runs
         ]
 
     def delete_run(self, name: str):
@@ -189,7 +187,7 @@ class Experiment:
                 )
 
         num_workers = kwargs.get(NUM_WORKERS, 4)
-        run_info = self._client.create_run(
+        run = self._client.create_run(
             run_name=run_name,
             experiment_name=self._name,
             run_config=config,
@@ -199,11 +197,11 @@ class Experiment:
         )
         run = Run(
             client=self._client,
-            name=run_info[NAME],
+            name=run[NAME],
             experiment_name=self._name,
-            config=run_info[CONFIG],
-            created_at=run_info[CREATED_AT],
-            description=run_info[DESCRIPTION],
+            config=run[CONFIG],
+            created_at=run[CREATED_AT],
+            description=run[DESCRIPTION],
         )
         return run
 

--- a/finetuner/experiment.py
+++ b/finetuner/experiment.py
@@ -89,12 +89,15 @@ class Experiment:
         )
         return run
 
-    def list_runs(self) -> List[Run]:
+    def list_runs(self, size: int = 50) -> List[Run]:
         """List every run inside the experiment.
 
+        :param size: Number of runs to retrieve.
         :return: List of `Run` objects.
         """
-        run_infos = self._client.list_runs(experiment_name=self._name)['items']
+        run_infos = self._client.list_runs(experiment_name=self._name, size=size)[
+            'items'
+        ]
         return [
             Run(
                 name=run_info[NAME],

--- a/finetuner/experiment.py
+++ b/finetuner/experiment.py
@@ -94,7 +94,7 @@ class Experiment:
 
         :return: List of `Run` objects.
         """
-        run_infos = self._client.list_runs(experiment_name=self._name)
+        run_infos = self._client.list_runs(experiment_name=self._name)['items']
         return [
             Run(
                 name=run_info[NAME],

--- a/finetuner/finetuner.py
+++ b/finetuner/finetuner.py
@@ -229,13 +229,16 @@ class Finetuner:
         return experiment.get_run(name=run_name)
 
     @login_required
-    def list_runs(self, experiment_name: Optional[str] = None) -> List[Run]:
+    def list_runs(
+        self, experiment_name: Optional[str] = None, size: int = 50
+    ) -> List[Run]:
         """List every run.
 
         If an experiment name is not specified, we'll list every run across all
         experiments.
 
         :param experiment_name: Optional name of the experiment.
+        :param size: Number of runs to retrieve.
         :return: A list of `Run` objects.
         """
         if not experiment_name:
@@ -244,7 +247,7 @@ class Finetuner:
             experiments = [self.get_experiment(name=experiment_name)]
         runs = []
         for experiment in experiments:
-            runs.extend(experiment.list_runs())
+            runs.extend(experiment.list_runs(size=size))
         return runs
 
     @login_required

--- a/finetuner/finetuner.py
+++ b/finetuner/finetuner.py
@@ -1,4 +1,3 @@
-import os
 from typing import Any, Dict, List, Optional, Union
 
 from docarray import DocumentArray
@@ -7,6 +6,7 @@ import hubble
 from finetuner.client import FinetunerV1Client
 from finetuner.constants import CREATED_AT, DESCRIPTION, NAME, STATUS
 from finetuner.data import CSVOptions
+from finetuner.excepts import FinetunerServerError
 from finetuner.experiment import Experiment
 from finetuner.run import Run
 from hubble import login_required
@@ -18,6 +18,7 @@ class Finetuner:
     def __init__(self):
         self._client = None
         self._default_experiment = None
+        self._default_experiment_name = 'default'
 
     def login(self, force: bool = False, interactive: Optional[bool] = None):
         """Login to Hubble account, initialize a client object
@@ -33,11 +34,6 @@ class Finetuner:
             force=force, post_success=self._init_state, interactive=interactive
         )
 
-    @staticmethod
-    def _get_cwd() -> str:
-        """Returns current working directory."""
-        return os.getcwd().split('/')[-1]
-
     @login_required
     def _init_state(self):
         """Initialize client and default experiment."""
@@ -47,29 +43,29 @@ class Finetuner:
     def _get_default_experiment(self) -> Experiment:
         """Create or retrieve (if it already exists) a default experiment
         for the current working directory."""
-        experiment_name = self._get_cwd()
         for experiment in self.list_experiments():
-            if experiment.name == experiment_name:
+            if experiment.name == self._default_experiment_name:
                 return experiment
-        return self.create_experiment(name=experiment_name)
+        return self.create_experiment(name=self._default_experiment_name)
 
     @login_required
-    def create_experiment(self, name: Optional[str] = None) -> Experiment:
+    def create_experiment(self, name: str = 'default') -> Experiment:
         """Create an experiment.
 
         :param name: Optional name of the experiment. If `None`,
             the experiment is named after the current directory.
         :return: An `Experiment` object.
         """
-        if not name:
-            name = self._get_cwd()
-        experiment_info = self._client.create_experiment(name=name)
+        try:
+            experiment = self._client.get_experiment(name=name)
+        except FinetunerServerError:
+            experiment = self._client.create_experiment(name=name)
         return Experiment(
             client=self._client,
-            name=experiment_info[NAME],
-            status=experiment_info[STATUS],
-            created_at=experiment_info[CREATED_AT],
-            description=experiment_info[DESCRIPTION],
+            name=experiment[NAME],
+            status=experiment[STATUS],
+            created_at=experiment[CREATED_AT],
+            description=experiment[DESCRIPTION],
         )
 
     @login_required
@@ -79,13 +75,13 @@ class Finetuner:
         :param name: Name of the experiment.
         :return: An `Experiment` object.
         """
-        experiment_info = self._client.get_experiment(name=name)
+        experiment = self._client.get_experiment(name=name)
         return Experiment(
             client=self._client,
-            name=experiment_info[NAME],
-            status=experiment_info[STATUS],
-            created_at=experiment_info[CREATED_AT],
-            description=experiment_info[DESCRIPTION],
+            name=experiment[NAME],
+            status=experiment[STATUS],
+            created_at=experiment[CREATED_AT],
+            description=experiment[DESCRIPTION],
         )
 
     @login_required
@@ -95,17 +91,17 @@ class Finetuner:
         :param size: The number of experiments to retrieve.
         :return: A list of :class:`Experiment`.
         """
-        experiment_infos = self._client.list_experiments(size=size)['items']
+        experiments = self._client.list_experiments(size=size)['items']
 
         return [
             Experiment(
                 client=self._client,
-                name=experiment_info[NAME],
-                status=experiment_info[STATUS],
-                created_at=experiment_info[CREATED_AT],
-                description=experiment_info[DESCRIPTION],
+                name=experiment[NAME],
+                status=experiment[STATUS],
+                created_at=experiment[CREATED_AT],
+                description=experiment[DESCRIPTION],
             )
-            for experiment_info in experiment_infos
+            for experiment in experiments
         ]
 
     @login_required
@@ -114,13 +110,13 @@ class Finetuner:
         :param name: Name of the experiment.
         :return: Deleted experiment.
         """
-        experiment_info = self._client.delete_experiment(name=name)
+        experiment = self._client.delete_experiment(name=name)
         return Experiment(
             client=self._client,
-            name=experiment_info[NAME],
-            status=experiment_info[STATUS],
-            created_at=experiment_info[CREATED_AT],
-            description=experiment_info[DESCRIPTION],
+            name=experiment[NAME],
+            status=experiment[STATUS],
+            created_at=experiment[CREATED_AT],
+            description=experiment[DESCRIPTION],
         )
 
     @login_required
@@ -128,16 +124,16 @@ class Finetuner:
         """Delete every experiment.
         :return: List of deleted experiments.
         """
-        experiment_infos = self._client.delete_experiments()
+        experiments = self._client.delete_experiments()
         return [
             Experiment(
                 client=self._client,
-                name=experiment_info[NAME],
-                status=experiment_info[STATUS],
-                created_at=experiment_info[CREATED_AT],
-                description=experiment_info[DESCRIPTION],
+                name=experiment[NAME],
+                status=experiment[STATUS],
+                created_at=experiment[CREATED_AT],
+                description=experiment[DESCRIPTION],
             )
-            for experiment_info in experiment_infos
+            for experiment in experiments
         ]
 
     @login_required

--- a/finetuner/finetuner.py
+++ b/finetuner/finetuner.py
@@ -89,9 +89,13 @@ class Finetuner:
         )
 
     @login_required
-    def list_experiments(self) -> List[Experiment]:
-        """List every experiment."""
-        experiment_infos = self._client.list_experiments()
+    def list_experiments(self, size: int = 50) -> List[Experiment]:
+        """List every experiment.
+
+        :param size: The number of experiments to retrieve.
+        :return: A list of :class:`Experiment`.
+        """
+        experiment_infos = self._client.list_experiments(size=size)['items']
 
         return [
             Experiment(

--- a/tests/integration/test_experiments.py
+++ b/tests/integration/test_experiments.py
@@ -15,17 +15,21 @@ def test_experiments(finetuner_mocker):
     finetuner_mocker.create_experiment(second_exp_name)
     experiments = finetuner_mocker.list_experiments()
     experiment_names = [experiment.name for experiment in experiments]
+    print(f'first exp is {first_exp_name}')
+    print(f'secon exp is {second_exp_name}')
+    for e in experiment_names:
+        print(e)
     assert first_exp_name in experiment_names and second_exp_name in experiment_names
 
-    for experiment in experiments:
-        assert experiment.status == 'ACTIVE'
+    # for experiment in experiments:
+    #     assert experiment.status == 'ACTIVE'
 
-    # delete the first experiment
-    finetuner_mocker.delete_experiment(first_exp_name)
-    experiments = finetuner_mocker.list_experiments()
-    assert second_exp_name in [experiment.name for experiment in experiments]
-
-    # delete all experiments
-    finetuner_mocker.delete_experiment(second_exp_name)
-    experiments = finetuner_mocker.list_experiments()
-    assert second_exp_name not in [experiment.name for experiment in experiments]
+    # # delete the first experiment
+    # finetuner_mocker.delete_experiment(first_exp_name)
+    # experiments = finetuner_mocker.list_experiments()
+    # assert second_exp_name in [experiment.name for experiment in experiments]
+    #
+    # # delete all experiments
+    # finetuner_mocker.delete_experiment(second_exp_name)
+    # experiments = finetuner_mocker.list_experiments()
+    # assert second_exp_name not in [experiment.name for experiment in experiments]

--- a/tests/integration/test_experiments.py
+++ b/tests/integration/test_experiments.py
@@ -29,3 +29,5 @@ def test_experiments(finetuner_mocker):
     finetuner_mocker.delete_experiment(second_exp_name)
     experiments = finetuner_mocker.list_experiments()
     assert second_exp_name not in [experiment.name for experiment in experiments]
+    # clear experiments
+    finetuner_mocker.delete_experiments()

--- a/tests/integration/test_experiments.py
+++ b/tests/integration/test_experiments.py
@@ -15,21 +15,17 @@ def test_experiments(finetuner_mocker):
     finetuner_mocker.create_experiment(second_exp_name)
     experiments = finetuner_mocker.list_experiments()
     experiment_names = [experiment.name for experiment in experiments]
-    print(f'first exp is {first_exp_name}')
-    print(f'secon exp is {second_exp_name}')
-    for e in experiment_names:
-        print(e)
     assert first_exp_name in experiment_names and second_exp_name in experiment_names
 
-    # for experiment in experiments:
-    #     assert experiment.status == 'ACTIVE'
+    for experiment in experiments:
+        assert experiment.status == 'ACTIVE'
 
-    # # delete the first experiment
-    # finetuner_mocker.delete_experiment(first_exp_name)
-    # experiments = finetuner_mocker.list_experiments()
-    # assert second_exp_name in [experiment.name for experiment in experiments]
-    #
-    # # delete all experiments
-    # finetuner_mocker.delete_experiment(second_exp_name)
-    # experiments = finetuner_mocker.list_experiments()
-    # assert second_exp_name not in [experiment.name for experiment in experiments]
+    # delete the first experiment
+    finetuner_mocker.delete_experiment(first_exp_name)
+    experiments = finetuner_mocker.list_experiments()
+    assert second_exp_name in [experiment.name for experiment in experiments]
+
+    # delete all experiments
+    finetuner_mocker.delete_experiment(second_exp_name)
+    experiments = finetuner_mocker.list_experiments()
+    assert second_exp_name not in [experiment.name for experiment in experiments]

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -60,7 +60,12 @@ def create_client_mocker(mocker):
 
     def return_experiments(**_):
         names = ['first experiment', 'second experiment']
-        return [return_experiment(name=name) for name in names]
+        return {
+            'items': [return_experiment(name=name) for name in names],
+            'total': 0,
+            'page': 1,
+            'size': len(names),
+        }
 
     def return_status(**_):
         return {
@@ -80,7 +85,12 @@ def create_client_mocker(mocker):
 
     def return_runs(**_):
         names = ['first run', 'second run']
-        return [return_run(run_name=name) for name in names]
+        return {
+            'items': [return_run(run_name=name) for name in names],
+            'total': 0,
+            'page': 1,
+            'size': len(names),
+        }
 
     base_mocker = _create_base_mocker(mocker)
 

--- a/tests/unit/test_finetuner.py
+++ b/tests/unit/test_finetuner.py
@@ -1,5 +1,3 @@
-import os
-
 import docarray
 import pytest
 
@@ -12,7 +10,7 @@ from finetuner.constants import CREATED, FAILED, FINISHED, STARTED, STATUS
 )
 def test_create_experiment(finetuner_mocker, experiment_name):
     experiment = finetuner_mocker.create_experiment(name=experiment_name)
-    expected_name = experiment_name or os.getcwd().split('/')[-1]
+    expected_name = experiment_name or 'default'
     assert experiment.name == expected_name
     assert experiment._status == 'ACTIVE'
 
@@ -37,7 +35,7 @@ def test_list_experiments(finetuner_mocker):
 def test_create_run(finetuner_mocker, experiment_name):
     data = docarray.DocumentArray().empty(1)
     run_name = 'run1'
-    exp_name = experiment_name or os.getcwd().split('/')[-1]
+    exp_name = experiment_name or 'default'
     run = finetuner_mocker.create_run(
         model='resnet50',
         train_data=data,
@@ -55,6 +53,6 @@ def test_create_run(finetuner_mocker, experiment_name):
 )
 def test_get_run(finetuner_mocker, experiment_name):
     run = finetuner_mocker.get_run(run_name='run_name', experiment_name=experiment_name)
-    exp_name = experiment_name or os.getcwd().split('/')[-1]
+    exp_name = experiment_name or 'default'
     assert run.name == 'run_name'
     assert run._experiment_name == exp_name

--- a/tests/unit/test_finetuner.py
+++ b/tests/unit/test_finetuner.py
@@ -9,7 +9,10 @@ from finetuner.constants import CREATED, FAILED, FINISHED, STARTED, STATUS
     ['exp name', None],
 )
 def test_create_experiment(finetuner_mocker, experiment_name):
-    experiment = finetuner_mocker.create_experiment(name=experiment_name)
+    if experiment_name:
+        experiment = finetuner_mocker.create_experiment(name=experiment_name)
+    else:
+        experiment = finetuner_mocker.create_experiment()
     expected_name = experiment_name or 'default'
     assert experiment.name == expected_name
     assert experiment._status == 'ACTIVE'


### PR DESCRIPTION
<!--- PR Description here --->

Due to our recent API changes (mostly paginated results), the staging env for integration test is not working anymore. In this PR the changes has been adopted, also added an extra parameter `size=50` to allow user set return number.

1. Update all endpoints based on recent API changes.
2. Change default `experiment_name` as `default`.
3. Remove `full-trace` from pytest to make github actions error messages easier to read.

---

- [x] This PR references an open issue
- [x] I have added a line about this change to CHANGELOG