### PR TITLE
docs: escape comma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improve walkthrough sections. ([#643](https://github.com/jina-ai/finetuner/pull/643))
 
+- Add hints to escape common to prepare csv training data. ([#655](https://github.com/jina-ai/finetuner/pull/655))
+
 
 ## [0.6.7] - 2022-11-25
 

--- a/docs/walkthrough/create-training-data.md
+++ b/docs/walkthrough/create-training-data.md
@@ -55,6 +55,11 @@ For 3D meshes the option `create_point_clouds` (`True` by default) creates point
 Please note, that local files can not be processed by the Finetuner if you deactivate `convert_to_blob` or `create_point_clouds`.
 ```
 
+```{important} 
+If the text field use commas,it breaks the CSV format since it's interpreted as a new column.
+In this case, please enclose the field in double quates, such as `field1,"field, 2",field3, ...`.
+```
+
 ````
 
 ````{tab} text-to-image search using CLIP

--- a/docs/walkthrough/create-training-data.md
+++ b/docs/walkthrough/create-training-data.md
@@ -56,7 +56,7 @@ Please note, that local files can not be processed by the Finetuner if you deact
 ```
 
 ```{important} 
-If the text field use commas,it breaks the CSV format since it's interpreted as a new column.
+If the text field use commas, it breaks the CSV format since it is interpreted as a new column.
 In this case, please enclose the field in double quates, such as `field1,"field, 2",field3, ...`.
 ```
 

--- a/docs/walkthrough/create-training-data.md
+++ b/docs/walkthrough/create-training-data.md
@@ -56,8 +56,8 @@ Please note, that local files can not be processed by the Finetuner if you deact
 ```
 
 ```{important} 
-If the text field use commas, it breaks the CSV format since it is interpreted as a new column.
-In this case, please enclose the field in double quates, such as `field1,"field, 2",field3, ...`.
+If the text field contains commas, it breaks the CSV format since it is interpreted as spanning over multiple columns.
+In this case, please enclose the field in double quotes, such as `field1,"field, 2"`.
 ```
 
 ````


### PR DESCRIPTION
<!--- PR Description here --->


Add hints in docs how to escape common when prepare training data using csv.

---

- [ ] This PR references an open issue
- [x] I have added a line about this change to CHANGELOG