### PR TITLE
docs: fix typos etc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add efficientnet b7 as a new image to image search backbone. ([#662](https://github.com/jina-ai/finetuner/pull/662))
 
+- Fix typos, duplicate paragraphs, and wrong formulations. ([#666](https://github.com/jina-ai/finetuner/pull/666)) 
+
 
 ## [0.7.0] - 2023-01-18
 

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ clustering, duplication detection, anomaly detection, or other uses.
 📈 **Performance promise**: Enhance the performance of pre-trained models so that they deliver state-of-the-art performance on 
 domain-specific applications.
 
-🔱 **Simple yet powerful**: Easy access to 40+ mainstream loss functions, 10+ optimisers, layer pruning, weight 
+🔱 **Simple yet powerful**: Easy access to 40+ mainstream loss functions, 10+ optimizers, layer pruning, weight
 freezing, dimensionality reduction, hard-negative mining, cross-modal models, and distributed training. 
 
-☁ **All-in-cloud**: Train using our free GPU infrastructure, manage runs, experiments and artifacts on Jina AI Cloud
+☁ **All-in-cloud**: Train using our free GPU infrastructure, manage runs, experiments, and artifacts on Jina AI Cloud
 without worrying about resource availability, complex integration, or infrastructure costs.
 
 <!-- end elevator-pitch -->

--- a/docs/advanced-topics/linear-probe.md
+++ b/docs/advanced-topics/linear-probe.md
@@ -54,7 +54,7 @@ run = finetuner.fit(
 
 Finetuner will:
 
-1. Remove the classification head of `ResNet` model, and convert it into an embedding model.
+1. Remove the classification head of a `ResNet` model, and convert it into an embedding model.
 2. Freeze all layers of the embedding model.
 3. Attach a trainable 3-layer Linear Projection Head on top of the embedding model with an `output_dim=1024`.
 

--- a/docs/advanced-topics/negative-mining.md
+++ b/docs/advanced-topics/negative-mining.md
@@ -61,7 +61,7 @@ For instance, if you choose to train a model with the `TripleMarginLoss`, you ca
 While without this miner, all possible triples with an anchor, a positive, and a negative candidate are used to calculate the loss, the miner reduces this set of triples.
 By default, the miner only selects triples with hard negatives where the distance between the positive and the negative example is inside a margin of `0.2`.
 To pass additional parameters to configure the miner, use the `miner_options` parameter of the fit function.
-For example, add the following to use only hard-negative triples and set the margin to `0.3`:
+For example, add the following to use only hard-negative triplets and set the margin to `0.3`:
 
 ```diff
 run = finetuner.fit(

--- a/docs/advanced-topics/negative-mining.md
+++ b/docs/advanced-topics/negative-mining.md
@@ -3,7 +3,7 @@
 
 Negative Mining is an advanced machine learning technique, which optimizes the way data is sampled from your training dataset.
 Usually, it aims at making the metric learning tasks for the model harder during the training. 
-In this way it can lead to better fine-tuning results.
+In this way, it can lead to better fine-tuning results.
 
 ## Context: Deep Metric Learning
 
@@ -22,8 +22,8 @@ Finetuner will evenly sample *X* items per class to make a batch *B* which is en
 
 Afterward, the loss is calculated based on the relations between the embeddings.
 Many of Finetuner's loss functions contrast the embeddings of three items, or a __Triplet__. 
-Finetuner creates all possible Triplets *(anchor, pos, neg)* from this batch which satisfy the following conditions:
-For each Triplet, the first is the __anchor__, the second is an embedding that ought to be closer to the embedding of the anchor (has the same label), and the third is one that should be further from the anchor (has a different label).
+Finetuner creates all possible triplets *(anchor, pos, neg)* from this batch which satisfy the following conditions:
+For each triplet, the first is the __anchor__, the second is an embedding that ought to be closer to the embedding of the anchor (has the same label), and the third is one that should be further from the anchor (has a different label).
 The objective is to pull the embeddings of items that belong to the same class closer together in the embedding space,
 while pushing the embeddings of items which belong to different classes farther away from each other.
 
@@ -32,12 +32,12 @@ while pushing the embeddings of items which belong to different classes farther 
 
 ## The Triplet Margin Miner
 
-For some Triplets, the pre-trained model already performs well, i.e.
+For some triplets, the pre-trained model already performs well, i.e.
 
 the distance between the `anchor` embedding and `pos` is much smaller than
 the distance between `anchor` and `neg`?
-These Triplets do not contribute to improving the model, since they are already in the desired relation to each other in the embedding space.
-A more effective way is to use only a subset of all Triplets for model training. We call this subset the **hard** or **semi-hard negative samples**.
+These triplets do not contribute to improving the model, since they are already in the desired relation to each other in the embedding space.
+A more effective way is to use only a subset of all triplets for model training. We call this subset the **hard** or **semi-hard negative samples**.
 
 ![mining](../imgs/mining.png)
 
@@ -49,7 +49,7 @@ If:
 + `D(anchor, pos) < D(anchor, neg) < D(anchor, pos) + margin`, where `neg` is a little further from the `pos`, but within the margin, then `neg` can be considered as a "semi-hard negative" (`2₄ - S`).
 + `D(anchor, neg) > D(anchor, pos) + margin`, then `neg` can be considered as "easy negative" (`2₄ - E`).
 
-Training is more effective when using only **hard** and **semi-hard** negatives, given a reasonable margin value to distinguish them from **easy** Triplets.
+Training is more effective when using only **hard** and **semi-hard** negatives, given a reasonable margin value to distinguish them from **easy** triplets.
 
 ## Doing Negative Mining in Finetuner
 
@@ -61,7 +61,7 @@ For instance, if you choose to train a model with the `TripleMarginLoss`, you ca
 While without this miner, all possible triples with an anchor, a positive, and a negative candidate are used to calculate the loss, the miner reduces this set of triples.
 By default, the miner only selects triples with hard negatives where the distance between the positive and the negative example is inside a margin of `0.2`.
 To pass additional parameters to configure the miner, use the `miner_options` parameter of the fit function.
-For example, to use only hard-negative Triples and set the margin to `0.3`:
+For example, add the following to use only hard-negative triples and set the margin to `0.3`:
 
 ```diff
 run = finetuner.fit(
@@ -84,6 +84,6 @@ For a detailed description of the miners and their parameters, see the [PyTorch 
 
 ## Summary
 
-Metric Learning and Triplets are extremely useful for fine-tuning models for similarity search.
-Easy Triplets have little impact on improving the model.
-Consider using semi-hard/hard Triplets for model tuning.
+Metric Learning and triplets are extremely useful for fine-tuning models for similarity search.
+Easy triplets have little impact on improving the model.
+Consider using semi-hard/hard triplets for model tuning.

--- a/docs/advanced-topics/using-callbacks.md
+++ b/docs/advanced-topics/using-callbacks.md
@@ -158,7 +158,8 @@ We can not ensure it works for other types of models, such as ResNet or BERT.
 
 Finetuner allows you to utilize Weights & Biases for experiment tracking and visualization.
 The `WandBLogger` uses Weights & Biases [Anonymous Mode](https://docs.wandb.ai/ref/app/features/anon)
-to track a Finetuner Run. The benefits of the anonymous mode are: you do not need to share your
+to track a Finetuner Run. The benefits of anonymous mode are: you do not need to share your
+
 Weights & Biases api_key with us since no login is required.
 
 ```{admonition} Use WandBLogger together with EvaluationCallback

--- a/docs/advanced-topics/using-callbacks.md
+++ b/docs/advanced-topics/using-callbacks.md
@@ -158,7 +158,7 @@ We can not ensure it works for other types of models, such as ResNet or BERT.
 
 Finetuner allows you to utilize Weights & Biases for experiment tracking and visualization.
 The `WandBLogger` uses Weights & Biases [Anonymous Mode](https://docs.wandb.ai/ref/app/features/anon)
-to track a Finetuner Run. The benefits of anonymous mode is: you do not need to share your
+to track a Finetuner Run. The benefits of the anonymous mode are: you do not need to share your
 Weights & Biases api_key with us since no login is required.
 
 ```{admonition} Use WandBLogger together with EvaluationCallback
@@ -166,7 +166,7 @@ Weights & Biases api_key with us since no login is required.
 The WandBLogger will track the training loss, plus the evaluation loss if `eval_data` is not None.
 
 If you use EvaluationCallback together with WandBLogger, search metrics will be tracked as well.
-Such as `mrr`, `precision`, `recall` etc.
+Such as `mrr`, `precision`, `recall`, etc.
 ```
 
 ```python

--- a/docs/get-started/how-it-works.md
+++ b/docs/get-started/how-it-works.md
@@ -6,7 +6,7 @@ This involves three steps:
 ## Step 1: Build an embedding model
 
 Finetuner takes an existing, pre-trained model, typically called the __backbone__, and analyzes its architecture.
-If this model does not already produce embeddings or the architecture not suitable for training it, Finetuner is able to remove the default *head* (the last layers of the network), add new projection layers, apply *pooling*, and freeze layers that do not need to be trained.
+If this model does not already produce embeddings or the architecture is not suitable for training it, Finetuner is able to remove the default *head* (the last layers of the network), add new projection layers, apply *pooling*, and freeze layers that do not need to be trained.
 
 For instance, Finetuner will turn an image classification model, e.g., for separating cats from dogs, into an *embedding model* 
 by removing its last layer - the classification head (cat-dog classifier).

--- a/docs/get-started/how-it-works.md
+++ b/docs/get-started/how-it-works.md
@@ -5,12 +5,8 @@ This involves three steps:
 
 ## Step 1: Build an embedding model
 
-Finetuner interprets the architecture of an existing (pre-trained model) which we call backbone.
-Those model might not be an embedding model upfront and the architecture not suitable for training it to encode data into embeddings.
-Therefore, Finetuner removes the default *head*, applies *pooling* and freezes layers that do not need to be trained.
-
 Finetuner takes an existing, pre-trained model, typically called the __backbone__, and analyzes its architecture.
-If this model does not already produce embeddings, Finetuner is able to remove the default *head* (the last layers of the network), add new projection layers, apply *pooling*, and freeze layers that do not need to be trained.
+If this model does not already produce embeddings or the architecture not suitable for training it, Finetuner is able to remove the default *head* (the last layers of the network), add new projection layers, apply *pooling*, and freeze layers that do not need to be trained.
 
 For instance, Finetuner will turn an image classification model, e.g., for separating cats from dogs, into an *embedding model* 
 by removing its last layer - the classification head (cat-dog classifier).

--- a/docs/get-started/how-it-works.md
+++ b/docs/get-started/how-it-works.md
@@ -6,7 +6,7 @@ This involves three steps:
 ## Step 1: Build an embedding model
 
 Finetuner takes an existing, pre-trained model, typically called the __backbone__, and analyzes its architecture.
-If this model does not already produce embeddings or the architecture is not suitable for training it, Finetuner is able to remove the default *head* (the last layers of the network), add new projection layers, apply *pooling*, and freeze layers that do not need to be trained.
+If this model does not already produce embeddings or the architecture is not suitable for training, Finetuner is able to remove the default *head* (the last layers of the network), add new projection layers, apply *pooling*, and freeze layers that do not need to be trained.
 
 For instance, Finetuner will turn an image classification model, e.g., for separating cats from dogs, into an *embedding model* 
 by removing its last layer - the classification head (cat-dog classifier).

--- a/docs/notebooks/image_to_image.ipynb
+++ b/docs/notebooks/image_to_image.ipynb
@@ -221,7 +221,7 @@
       "source": [
         "## Evaluating\n",
         "Currently, we don't have a user-friendly way to get evaluation metrics from the `finetuner.callback.EvaluationCallback` we initialized previously.\n",
-        "What you can do for now is to call `run.logs()` in the end of the run and see the evaluation results:\n",
+        "What you can do for now is to call `run.logs()` after the end of the run and see the evaluation results:\n",
         "\n",
         "```bash\n",
         "  Training [5/5] ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 76/76 0:00:00 0:03:15 • loss: 0.003\n",

--- a/docs/notebooks/image_to_image.ipynb
+++ b/docs/notebooks/image_to_image.ipynb
@@ -22,9 +22,9 @@
         "\n",
         "<a href=\"https://colab.research.google.com/drive/1QuUTy3iVR-kTPljkwplKYaJ-NTCgPEc_?usp=sharing\"><img alt=\"Open In Colab\" src=\"https://colab.research.google.com/assets/colab-badge.svg\"></a>\n",
         "\n",
-        "Searching visually similar images with image queries is a very popular use-case. However, using pre-trained models does not deliver the best results – the models are trained on general data that lack the particularities of your specific task. Here's where Finetuner comes in! It enables you to accomplish this easily.\n",
+        "Searching visually similar images with image queries is a very popular use case. However, using pre-trained models does not deliver the best results – the models are trained on general data that lack the particularities of your specific task. Here's where Finetuner comes in! It enables you to accomplish this easily.\n",
         "\n",
-        "This guide will demonstrate how to fine-tune a ResNet model for image to image retrieval.\n",
+        "This guide will demonstrate how to fine-tune a ResNet model for image-to-image retrieval.\n",
         "\n",
         "*Note, please consider switching to GPU/TPU Runtime for faster inference.*\n",
         "\n",
@@ -221,7 +221,7 @@
       "source": [
         "## Evaluating\n",
         "Currently, we don't have a user-friendly way to get evaluation metrics from the `finetuner.callback.EvaluationCallback` we initialized previously.\n",
-        "What you can do for now is to call `run.logs()` in the end of the run and see evaluation results:\n",
+        "What you can do for now is to call `run.logs()` in the end of the run and see the evaluation results:\n",
         "\n",
         "```bash\n",
         "  Training [5/5] ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 76/76 0:00:00 0:03:15 • loss: 0.003\n",
@@ -306,7 +306,7 @@
     {
       "cell_type": "markdown",
       "source": [
-        "And finally you can use the embeded `query` to find top-k visually related images within `index_data` as follows:"
+        "And finally, you can use the embedded `query` to find top-k visually related images within `index_data` as follows:"
       ],
       "metadata": {
         "id": "1cC46TQ9pw-H"
@@ -327,7 +327,7 @@
       "cell_type": "markdown",
       "source": [
         "## Before and after\n",
-        "We can directly compare the results of our fine-tuned model with its zero-shot counterpart to get a better idea of how finetuning affects the results of a search. While the differences between the two models may be subtle for some queries, some of the examples the examples below (such as the second example) show that the model after fine-tuning is able to better match similar images."
+        "We can directly compare the results of our fine-tuned model with its zero-shot counterpart to get a better idea of how finetuning affects the results of a search. While the differences between the two models may be subtle for some queries, some of the examples below (such as the second example) show that the model after fine-tuning is able to better match similar images."
       ],
       "metadata": {
         "id": "irvn0igWdLOf"
@@ -340,7 +340,7 @@
         "\n",
         "![image-image-triplets-good](https://user-images.githubusercontent.com/6599259/212634591-03bd93dc-900f-47c5-8ada-77cf1d4f9fe6.png)\n",
         "\n",
-        "On the other hand, there are also cases where the fine-tuned model performs worse, and fails to correctly match images that it previously could. This case is much rarer than the previous case. For this dataset there were 108 occasions where the fine-tuned model returned the correct pair where it couldn't before, and only 33 occasions where the finetuned model returned an incorrect image after fine-tuning but returned a correct one before. Nevertheless it still can happen:\n",
+        "On the other hand, there are also cases where the fine-tuned model performs worse, and fails to correctly match images that it previously could. This case is much rarer than the previous case. For this dataset, there were 108 occasions where the fine-tuned model returned the correct pair where it couldn't before and only 33 occasions where the finetuned model returned an incorrect image after fine-tuning but returned a correct one before. Nevertheless, it still can happen:\n",
         "\n",
         "![image-image-triplets-bad](https://user-images.githubusercontent.com/6599259/212634649-370b643b-63ad-4d46-8a16-bc4988265568.png)"
       ],

--- a/docs/notebooks/image_to_image.md
+++ b/docs/notebooks/image_to_image.md
@@ -140,7 +140,7 @@ You can continue monitoring the runs by checking the status - `finetuner.run.Run
 <!-- #region id="BMpQxydypeZ3" -->
 ## Evaluating
 Currently, we don't have a user-friendly way to get evaluation metrics from the `finetuner.callback.EvaluationCallback` we initialized previously.
-What you can do for now is to call `run.logs()` in the end of the run and see the evaluation results:
+What you can do for now is to call `run.logs()` after the end of the run and see the evaluation results:
 
 ```bash
   Training [5/5] ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 76/76 0:00:00 0:03:15 • loss: 0.003

--- a/docs/notebooks/image_to_image.md
+++ b/docs/notebooks/image_to_image.md
@@ -16,9 +16,9 @@ jupyter:
 
 <a href="https://colab.research.google.com/drive/1QuUTy3iVR-kTPljkwplKYaJ-NTCgPEc_?usp=sharing"><img alt="Open In Colab" src="https://colab.research.google.com/assets/colab-badge.svg"></a>
 
-Searching visually similar images with image queries is a very popular use-case. However, using pre-trained models does not deliver the best results – the models are trained on general data that lack the particularities of your specific task. Here's where Finetuner comes in! It enables you to accomplish this easily.
+Searching visually similar images with image queries is a very popular use case. However, using pre-trained models does not deliver the best results – the models are trained on general data that lack the particularities of your specific task. Here's where Finetuner comes in! It enables you to accomplish this easily.
 
-This guide will demonstrate how to fine-tune a ResNet model for image to image retrieval.
+This guide will demonstrate how to fine-tune a ResNet model for image-to-image retrieval.
 
 *Note, please consider switching to GPU/TPU Runtime for faster inference.*
 
@@ -140,7 +140,7 @@ You can continue monitoring the runs by checking the status - `finetuner.run.Run
 <!-- #region id="BMpQxydypeZ3" -->
 ## Evaluating
 Currently, we don't have a user-friendly way to get evaluation metrics from the `finetuner.callback.EvaluationCallback` we initialized previously.
-What you can do for now is to call `run.logs()` in the end of the run and see evaluation results:
+What you can do for now is to call `run.logs()` in the end of the run and see the evaluation results:
 
 ```bash
   Training [5/5] ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 76/76 0:00:00 0:03:15 • loss: 0.003
@@ -197,7 +197,7 @@ assert query.embeddings.shape == (1, 2048)
 ```
 
 <!-- #region id="1cC46TQ9pw-H" -->
-And finally you can use the embeded `query` to find top-k visually related images within `index_data` as follows:
+And finally, you can use the embedded `query` to find top-k visually related images within `index_data` as follows:
 <!-- #endregion -->
 
 ```python id="tBYG9OKrpZ36"
@@ -206,7 +206,7 @@ query.match(index_data, limit=10, metric='cosine')
 
 <!-- #region id="irvn0igWdLOf" -->
 ## Before and after
-We can directly compare the results of our fine-tuned model with its zero-shot counterpart to get a better idea of how finetuning affects the results of a search. While the differences between the two models may be subtle for some queries, some of the examples the examples below (such as the second example) show that the model after fine-tuning is able to better match similar images.
+We can directly compare the results of our fine-tuned model with its zero-shot counterpart to get a better idea of how finetuning affects the results of a search. While the differences between the two models may be subtle for some queries, some of the examples below (such as the second example) show that the model after fine-tuning is able to better match similar images.
 <!-- #endregion -->
 
 <!-- #region id="TwL33Jz1datD" -->
@@ -214,7 +214,7 @@ To save you some time, we have plotted some examples where the model's ability t
 
 ![image-image-triplets-good](https://user-images.githubusercontent.com/6599259/212634591-03bd93dc-900f-47c5-8ada-77cf1d4f9fe6.png)
 
-On the other hand, there are also cases where the fine-tuned model performs worse, and fails to correctly match images that it previously could. This case is much rarer than the previous case. For this dataset there were 108 occasions where the fine-tuned model returned the correct pair where it couldn't before, and only 33 occasions where the finetuned model returned an incorrect image after fine-tuning but returned a correct one before. Nevertheless it still can happen:
+On the other hand, there are also cases where the fine-tuned model performs worse, and fails to correctly match images that it previously could. This case is much rarer than the previous case. For this dataset, there were 108 occasions where the fine-tuned model returned the correct pair where it couldn't before and only 33 occasions where the finetuned model returned an incorrect image after fine-tuning but returned a correct one before. Nevertheless, it still can happen:
 
 ![image-image-triplets-bad](https://user-images.githubusercontent.com/6599259/212634649-370b643b-63ad-4d46-8a16-bc4988265568.png)
 <!-- #endregion -->

--- a/docs/notebooks/mesh_to_mesh.ipynb
+++ b/docs/notebooks/mesh_to_mesh.ipynb
@@ -1,55 +1,47 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "provenance": []
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "C0RxIJmLkTGk"
+      },
       "source": [
         "# 3D Mesh-to-3D Mesh Search via PointNet++\n",
         "\n",
         "<a href=\"https://colab.research.google.com/drive/1lIMDFkUVsWMshU-akJ_hwzBfJ37zLFzU?usp=sharing\"><img alt=\"Open In Colab\" src=\"https://colab.research.google.com/assets/colab-badge.svg\"></a>\n",
         "\n",
         "Finding similar 3D Meshes can become very time-consuming. To support this task, one can build search systems. To directly search on the 3D meshes without relying on metadata one can use an encoder model which creates a point cloud from the mesh and encode it into vector dense representations which can be compared to each other. To enable those models to detect the right attributes of a 3D mesh, this tutorial shows you how to use Finetuner to train and use a model for a 3D mesh search system."
-      ],
-      "metadata": {
-        "id": "C0RxIJmLkTGk"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "## Install"
-      ],
       "metadata": {
         "id": "mk4gxLZnYJry"
-      }
+      },
+      "source": [
+        "## Install"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "background_save": true
+        },
+        "id": "vDVkw65kkQcn"
+      },
+      "outputs": [],
       "source": [
         "!pip install 'finetuner[full]'\n",
         "!pip install 'docarray[full]'"
-      ],
-      "metadata": {
-        "id": "vDVkw65kkQcn"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "q7Bb9o5ZHSZ3"
+      },
       "source": [
         "## Task\n",
         "\n",
@@ -57,13 +49,13 @@
         "\n",
         "We demonstrate this on the [Modelnet40](https://modelnet.cs.princeton.edu/) dataset, which consists of more than 12k 3D meshes of objects from 40 classes.\n",
         "Specifically, we want to build a search system, which can receive a 3D mesh and retrieves meshes of the same class.\n"
-      ],
-      "metadata": {
-        "id": "q7Bb9o5ZHSZ3"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "H1Yo3NuGP1Oi"
+      },
       "source": [
         "## Data\n",
         "\n",
@@ -80,93 +72,95 @@
         "```\n",
         "\n",
         "The code below loads the data and prints a summary of the training datasets:"
-      ],
-      "metadata": {
-        "id": "H1Yo3NuGP1Oi"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "uTDreSwfYGOR"
+      },
+      "outputs": [],
       "source": [
         "import finetuner\n",
         "from docarray import DocumentArray, Document\n",
         "\n",
         "finetuner.login(force=True)"
-      ],
-      "metadata": {
-        "id": "uTDreSwfYGOR"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "Y-Um5gE8IORv"
+      },
+      "outputs": [],
       "source": [
         "train_data = DocumentArray.pull('finetuner/modelnet40-train', show_progress=True)\n",
         "query_data = DocumentArray.pull('finetuner/modelnet40-queries', show_progress=True)\n",
         "index_data = DocumentArray.pull('finetuner/modelnet40-index', show_progress=True)\n",
         "\n",
         "train_data.summary()"
-      ],
-      "metadata": {
-        "id": "Y-Um5gE8IORv"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "Now, we want to take a look at the point clouds of some of the meshes. Therefore, you can use the [`display`](https://docarray.jina.ai/api/docarray.document/#docarray.document.Document.display) function:"
-      ],
       "metadata": {
         "id": "r4cP95RzLybw"
-      }
+      },
+      "source": [
+        "Now, we want to take a look at the point clouds of some of the meshes. Therefore, you can use the [`display`](https://docarray.jina.ai/api/docarray.document/#docarray.document.Document.display) function:"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "index_data[0].display()"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "kCv455NPMD1O"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "index_data[0].display()"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "![A point cloud example](https://user-images.githubusercontent.com/6599259/208113813-bcf498d9-edf7-4496-a087-03bb783f3b70.png)"
-      ],
       "metadata": {
         "id": "XlttkaD5Omhk"
-      }
+      },
+      "source": [
+        "![A point cloud example](https://user-images.githubusercontent.com/6599259/208113813-bcf498d9-edf7-4496-a087-03bb783f3b70.png)"
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "B3I_QUeFT_V0"
+      },
       "source": [
         "## Backbone model\n",
         "\n",
-        "The model we provide for 3d mesh encoding is called `pointnet++`. In the following, we show you how to train it on the modelnet training dataset."
-      ],
-      "metadata": {
-        "id": "B3I_QUeFT_V0"
-      }
+        "The model we provide for 3d mesh encoding is called `pointnet++`. In the following, we show you how to train it on the ModelNet training dataset."
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "lqg0eY9oknLL"
+      },
       "source": [
         "## Fine-tuning\n",
         "\n",
         "Now that we have data for training and evaluation. as well as the name of the model, which we want to train, we can configure and submit a fine-tuning run:"
-      ],
-      "metadata": {
-        "id": "lqg0eY9oknLL"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "rR22MbgITp8M"
+      },
+      "outputs": [],
       "source": [
         "from finetuner.callback import EvaluationCallback\n",
         "\n",
@@ -186,15 +180,13 @@
         "        )\n",
         "    ],\n",
         ")"
-      ],
-      "metadata": {
-        "id": "rR22MbgITp8M"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "ossT9LH1oh6K"
+      },
       "source": [
         "Let's understand what this piece of code does:\n",
         "\n",
@@ -203,37 +195,37 @@
         "* We also provide some hyper-parameters such as the number of `epochs`, `batch_size`, and a `learning_rate`.\n",
         "* We use `TripletMarginLoss` to optimize the PointNet++ model.\n",
         "* We use an evaluation callback, which uses the fine-tuned model for encoding the text queries and meshes in the index data collection. It also accepts the `batch_size` attribute. By encoding 64 meshes at once, the evaluation gets faster.\n"
-      ],
-      "metadata": {
-        "id": "ossT9LH1oh6K"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "AsHsMJP6p7Co"
+      },
       "source": [
         "## Monitoring\n",
         "\n",
         "Now that we've created a run, let's see how it's processing. You can monitor the run by checking the status via `run.status()` and view the logs with `run.logs()`. To stream logs, call `run.stream_logs()`:"
-      ],
-      "metadata": {
-        "id": "AsHsMJP6p7Co"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "PCCRZ6PalsK3"
+      },
+      "outputs": [],
       "source": [
         "# note, the fine-tuning might takes 20~ minutes\n",
         "for entry in run.stream_logs():\n",
         "    print(entry)"
-      ],
-      "metadata": {
-        "id": "PCCRZ6PalsK3"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "zG7Uci-qqkzM"
+      },
       "source": [
         "Since some runs might take up to several hours/days, it's important to know how to reconnect to Finetuner and retrieve your run.\n",
         "\n",
@@ -245,13 +237,13 @@
         "```\n",
         "\n",
         "You can continue monitoring the run by checking the status - `finetuner.run.Run.status()` or the logs - `finetuner.run.Run.logs()`."
-      ],
-      "metadata": {
-        "id": "zG7Uci-qqkzM"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "WgTrq9D5q0zc"
+      },
       "source": [
         "## Evaluating\n",
         "\n",
@@ -275,46 +267,48 @@
         "           INFO     Finished 🚀                                                                                                                                        __main__.py:246\n",
         "\n",
         "```\n"
-      ],
-      "metadata": {
-        "id": "WgTrq9D5q0zc"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "W4ZCKUOfq9oC"
+      },
       "source": [
         "\n",
         "After the run has finished successfully, you can download the tuned model on your local machine:"
-      ],
-      "metadata": {
-        "id": "W4ZCKUOfq9oC"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "artifact = run.save_artifact('pointnet_model')"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "K5UdKleiqd8m"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "artifact = run.save_artifact('pointnet_model')"
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "JU3uUVyirTE1"
+      },
       "source": [
         "## Inference\n",
         "\n",
         "Now you saved the `artifact` into your host machine,\n",
         "let's use the fine-tuned model to encode a new `Document`:"
-      ],
-      "metadata": {
-        "id": "JU3uUVyirTE1"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "rDGxi7kVq_sH"
+      },
+      "outputs": [],
       "source": [
         "model = finetuner.get_model(artifact=artifact, device='cuda')\n",
         "\n",
@@ -322,44 +316,44 @@
         "finetuner.encode(model=model, data=index_data)\n",
         "\n",
         "assert query.embeddings.shape == (1, 512)"
-      ],
-      "metadata": {
-        "id": "rDGxi7kVq_sH"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "And finally you can use the embeded `query` to find top-k visually related images within `index_data` as follows:"
-      ],
       "metadata": {
         "id": "pfoc4YG4rrkI"
-      }
+      },
+      "source": [
+        "And finally, you can use the embedded `query` to find top-k visually related images within `index_data` as follows:"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "query_data.match(index_data, limit=10, metric='cosine')"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "_jGsSyedrsJp"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "query_data.match(index_data, limit=10, metric='cosine')"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "To compare the matches against results obtained with a PointNet++ model without training, you can use the `build_model` function:"
-      ],
       "metadata": {
         "id": "xGAjr26o6j-n"
-      }
+      },
+      "source": [
+        "To compare the matches against results obtained with a PointNet++ model without training, you can use the `build_model` function:"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "cChTjw3b6iXq"
+      },
+      "outputs": [],
       "source": [
         "zero_shot_model = finetuner.build_model('pointnet++')\n",
         "\n",
@@ -367,47 +361,56 @@
         "finetuner.encode(model=zero_shot_model, data=index_data)\n",
         "\n",
         "query_data.match(index_data, limit=10, metric='cosine')"
-      ],
-      "metadata": {
-        "id": "cChTjw3b6iXq"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "CgZHPInNWWHn"
+      },
       "source": [
         "## Before and After\n",
         "\n",
         "After the inference, you can investigate the results with the [`display`](https://docarray.jina.ai/api/docarray.document/#docarray.document.Document.display) function, as shown in the code block below:"
-      ],
-      "metadata": {
-        "id": "CgZHPInNWWHn"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "query_data[5].display()\n",
-        "query_data[5].matches[0].display()"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "p37Ryip2dKoO"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "query_data[5].display()\n",
+        "query_data[5].matches[0].display()"
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "lybyfx6OdMJL"
+      },
       "source": [
         "While you will notice that the PointNet++ might already deliver good results for some queries without training, the fine-tuned model does perform better on many queries like the ones shown below:\n",
         "\n",
         "![Results](https://user-images.githubusercontent.com/6599259/208681224-aa3263f2-326a-4c66-baf0-7fa1dbf594a2.png)\n",
         "\n"
-      ],
-      "metadata": {
-        "id": "lybyfx6OdMJL"
-      }
+      ]
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/docs/notebooks/mesh_to_mesh.ipynb
+++ b/docs/notebooks/mesh_to_mesh.ipynb
@@ -59,7 +59,7 @@
       "source": [
         "## Data\n",
         "\n",
-        "ModelNet40 consists of 9843 meshes provided for training and 2468 meshes for testing. Usually, you would have to download the [dataset](https://modelnet.cs.princeton.edu/) unzip it, [prepare it, and upload it to the Jina AI Cloud](https://https://finetuner.jina.ai/walkthrough/create-training-data/). After that, you can provide the name of the dataset used for the upload to Finetuner.\n",
+        "ModelNet40 consists of 9843 meshes provided for training and 2468 meshes for testing. Usually, you would have to download the [dataset](https://modelnet.cs.princeton.edu/) unzip it, [prepare it, and upload it to the Jina AI Cloud](https://finetuner.jina.ai/walkthrough/create-training-data/). After that, you can provide the name of the dataset used for the upload to Finetuner.\n",
         "\n",
         "For this tutorial, we already prepared the data and uploaded it. Specifically, the training data is uploaded as `modelnet40-train`. For evaluating the model, we split the test set of the original dataset into 300 meshes, which serve as queries (`modelnet40-queries`), and 2168 meshes which serve as the mesh collection, which is searched in (`modelnet40-index`).\n",
         "\n",

--- a/docs/notebooks/mesh_to_mesh.md
+++ b/docs/notebooks/mesh_to_mesh.md
@@ -41,7 +41,7 @@ Specifically, we want to build a search system, which can receive a 3D mesh and 
 <!-- #region id="H1Yo3NuGP1Oi" -->
 ## Data
 
-ModelNet40 consists of 9843 meshes provided for training and 2468 meshes for testing. Usually, you would have to download the [dataset](https://modelnet.cs.princeton.edu/) unzip it, [prepare it, and upload it to the Jina AI Cloud](https://https://finetuner.jina.ai/walkthrough/create-training-data/). After that, you can provide the name of the dataset used for the upload to Finetuner.
+ModelNet40 consists of 9843 meshes provided for training and 2468 meshes for testing. Usually, you would have to download the [dataset](https://modelnet.cs.princeton.edu/) unzip it, [prepare it, and upload it to the Jina AI Cloud](https://finetuner.jina.ai/walkthrough/create-training-data/). After that, you can provide the name of the dataset used for the upload to Finetuner.
 
 For this tutorial, we already prepared the data and uploaded it. Specifically, the training data is uploaded as `modelnet40-train`. For evaluating the model, we split the test set of the original dataset into 300 meshes, which serve as queries (`modelnet40-queries`), and 2168 meshes which serve as the mesh collection, which is searched in (`modelnet40-index`).
 

--- a/docs/notebooks/mesh_to_mesh.md
+++ b/docs/notebooks/mesh_to_mesh.md
@@ -23,7 +23,7 @@ Finding similar 3D Meshes can become very time-consuming. To support this task, 
 ## Install
 <!-- #endregion -->
 
-```python id="vDVkw65kkQcn"
+```python colab={"background_save": true} id="vDVkw65kkQcn"
 !pip install 'finetuner[full]'
 !pip install 'docarray[full]'
 ```
@@ -41,7 +41,7 @@ Specifically, we want to build a search system, which can receive a 3D mesh and 
 <!-- #region id="H1Yo3NuGP1Oi" -->
 ## Data
 
-ModelNet40 consists of 9843 meshes provided for training and 2468 meshes for testing. Usually, you would have to download the [dataset](https://modelnet.cs.princeton.edu/) unzip it, [prepare it, and upload it to the Jina AI Cloud](https://finetuner.jina.ai/walkthrough/create-training-data/). After that, you can provide the name of the dataset used for the upload to Finetuner.
+ModelNet40 consists of 9843 meshes provided for training and 2468 meshes for testing. Usually, you would have to download the [dataset](https://modelnet.cs.princeton.edu/) unzip it, [prepare it, and upload it to the Jina AI Cloud](https://https://finetuner.jina.ai/walkthrough/create-training-data/). After that, you can provide the name of the dataset used for the upload to Finetuner.
 
 For this tutorial, we already prepared the data and uploaded it. Specifically, the training data is uploaded as `modelnet40-train`. For evaluating the model, we split the test set of the original dataset into 300 meshes, which serve as queries (`modelnet40-queries`), and 2168 meshes which serve as the mesh collection, which is searched in (`modelnet40-index`).
 
@@ -86,7 +86,7 @@ index_data[0].display()
 <!-- #region id="B3I_QUeFT_V0" -->
 ## Backbone model
 
-The model we provide for 3d mesh encoding is called `pointnet++`. In the following, we show you how to train it on the modelnet training dataset.
+The model we provide for 3d mesh encoding is called `pointnet++`. In the following, we show you how to train it on the ModelNet training dataset.
 <!-- #endregion -->
 
 <!-- #region id="lqg0eY9oknLL" -->
@@ -204,7 +204,7 @@ assert query.embeddings.shape == (1, 512)
 ```
 
 <!-- #region id="pfoc4YG4rrkI" -->
-And finally you can use the embeded `query` to find top-k visually related images within `index_data` as follows:
+And finally, you can use the embedded `query` to find top-k visually related images within `index_data` as follows:
 <!-- #endregion -->
 
 ```python id="_jGsSyedrsJp"

--- a/docs/notebooks/multilingual_text_to_image.ipynb
+++ b/docs/notebooks/multilingual_text_to_image.ipynb
@@ -239,7 +239,7 @@
       },
       "source": [
         "## Evaluating\n",
-        "Once the run is finished, the metrics calculated by the {class}`~finetuner.callback.EvaluationCallback` are plotted using the {class}`~finetuner.callback.WandBLogger` callback. These plots can be accessed using the link provided in the logs once finetuning starts:\n",
+        "Once the run is finished, the metrics are calculated by the {class}`~finetuner.callback.EvaluationCallback` and plotted using the {class}`~finetuner.callback.WandBLogger` callback. These plots can be accessed using the link provided in the logs once finetuning starts:\n",
         "\n",
         "```bash\n",
         "           INFO     Finetuning ... \n",
@@ -361,7 +361,7 @@
       },
       "source": [
         "## Before and after\n",
-        "We can directly compare the results of our fine-tuned model with an untrained multilingual clip model by displaying the matches each model has for the same query, while the differences between the results of the two models are quite subtle for some queries, the examples below clearly show that finetuning increses the quality of the search results:"
+        "We can directly compare the results of our fine-tuned model with an untrained multilingual clip model by displaying the matches each model has for the same query, while the differences between the results of the two models are quite subtle for some queries, the examples below clearly show that fine-tuning increases the quality of the search results:"
       ]
     },
     {

--- a/docs/notebooks/multilingual_text_to_image.md
+++ b/docs/notebooks/multilingual_text_to_image.md
@@ -139,7 +139,7 @@ You can continue monitoring the run by checking the status - `finetuner.run.Run.
 
 <!-- #region id="f0b81ec1-2e02-472f-b2f4-27085bb041cc" -->
 ## Evaluating
-Once the run is finished, the metrics calculated by the {class}`~finetuner.callback.EvaluationCallback` are plotted using the {class}`~finetuner.callback.WandBLogger` callback. These plots can be accessed using the link provided in the logs once finetuning starts:
+Once the run is finished, the metrics are calculated by the {class}`~finetuner.callback.EvaluationCallback` and plotted using the {class}`~finetuner.callback.WandBLogger` callback. These plots can be accessed using the link provided in the logs once finetuning starts:
 
 ```bash
            INFO     Finetuning ... 
@@ -222,7 +222,7 @@ please use `model = finetuner.get_model(artifact, is_onnx=True)`
 
 <!-- #region id="38bc9069-0f0e-47c6-8560-bf77ad200774" -->
 ## Before and after
-We can directly compare the results of our fine-tuned model with an untrained multilingual clip model by displaying the matches each model has for the same query, while the differences between the results of the two models are quite subtle for some queries, the examples below clearly show that finetuning increses the quality of the search results:
+We can directly compare the results of our fine-tuned model with an untrained multilingual clip model by displaying the matches each model has for the same query, while the differences between the results of the two models are quite subtle for some queries, the examples below clearly show that fine-tuning increases the quality of the search results:
 <!-- #endregion -->
 
 <!-- #region id="e69fdfb2-6482-45fb-9c4d-41e548ef8f06" -->

--- a/docs/notebooks/text_to_image.ipynb
+++ b/docs/notebooks/text_to_image.ipynb
@@ -345,7 +345,7 @@
         ")\n",
         "```\n",
         "\n",
-        "The value you set to `alpha` should be greater or equal to 0 and less equal to 1:\n",
+        "The value you set to `alpha` should be greater or equal to 0 and less or equal to 1:\n",
         "\n",
         "+ if `alpha` is a float between 0 and 1, we merge the weights between the pre-trained model and the fine-tuned model.\n",
         "+ if `alpha` is 0, the fine-tuned model is identical to the pre-trained model.\n",

--- a/docs/notebooks/text_to_image.ipynb
+++ b/docs/notebooks/text_to_image.ipynb
@@ -22,11 +22,11 @@
         "\n",
         "<a href=\"https://colab.research.google.com/drive/1yKnmy2Qotrh3OhgwWRsMWPFwOSAecBxg?usp=sharing\"><img alt=\"Open In Colab\" src=\"https://colab.research.google.com/assets/colab-badge.svg\"></a>\n",
         "\n",
-        "Traditionally, searching images from text (text-image-retrieval) relies heavily on human annotations, this is commonly referred to as *Text/Tag based Image Retrieval (TBIR)*.\n",
+        "Traditionally, searching images from text (text-image-retrieval) relies heavily on human annotations, this is commonly referred to as *Text/Tag-based Image Retrieval (TBIR)*.\n",
         "\n",
         "The [OpenAI CLIP](https://github.com/openai/CLIP) model maps the dense vectors extracted from text and image into the same semantic space and produces a strong zero-shot model to measure the similarity between text and images.\n",
         "\n",
-        "This guide will showcase fine-tuning a `CLIP` model for text to image retrieval.\n",
+        "This guide will showcase fine-tuning a `CLIP` model for text-to-image retrieval.\n",
         "\n",
         "*Note, please consider switching to GPU/TPU Runtime for faster inference.*\n",
         "\n",
@@ -53,7 +53,7 @@
         "## Task\n",
         "We'll be fine-tuning CLIP on the [fashion captioning dataset](https://github.com/xuewyang/Fashion_Captioning) which contains information about fashion products.\n",
         "\n",
-        "For each product the dataset contains a title and images of multiple variants of the product. We constructed a parent [`Document`](https://docarray.jina.ai/fundamentals/document/#document) for each picture, which contains two [chunks](https://docarray.jina.ai/fundamentals/document/nested/#nested-structure): an image document and a text document holding the description of the product."
+        "For each product, the dataset contains a title and images of multiple variants of the product. We constructed a parent [`Document`](https://docarray.jina.ai/fundamentals/document/#document) for each picture, which contains two [chunks](https://docarray.jina.ai/fundamentals/document/nested/#nested-structure): an image document and a text document holding the description of the product."
       ],
       "metadata": {
         "id": "GXddluSIwCGW"
@@ -64,7 +64,7 @@
       "source": [
         "## Data\n",
         "Our journey starts locally. We have to [prepare the data and push it to the Jina AI Cloud](https://finetuner.jina.ai/walkthrough/create-training-data/) and Finetuner will be able to get the dataset by its name. For this example,\n",
-        "we already prepared the data, and we'll provide the names of traning and evaluation data (`fashion-train-data-clip` and `fashion-eval-data-clip`) directly to Finetuner.\n",
+        "we already prepared the data, and we'll provide the names of training and evaluation data (`fashion-train-data-clip` and `fashion-eval-data-clip`) directly to Finetuner.\n",
         "In addition, we also provide labeled queries and an index of labeled documents for evaluating the retrieval capabilities of the resulting fine-tuned model stored in the datasets `fashion-eval-data-queries` and `fashion-eval-data-index`.\n",
         "\n",
         "\n",
@@ -165,7 +165,7 @@
         "Let's understand what this piece of code does:\n",
         "\n",
         "* We start with providing `model`, names of training and evaluation data.\n",
-        "* We also provide some hyper-parameters such as number of `epochs` and a `learning_rate`.\n",
+        "* We also provide some hyperparameters such as number of `epochs` and a `learning_rate`.\n",
         "* We use `CLIPLoss` to optimize the CLIP model.\n",
         "* We use an evaluation callback, which uses the `'clip-text'` model for encoding the text queries and the `'clip-vision'` model for encoding the images in `'fashion-eval-data-index'`.\n"
       ],
@@ -345,14 +345,14 @@
         ")\n",
         "```\n",
         "\n",
-        "The value you set to `alpha` should be greater equal than 0 and less equal than 1:\n",
+        "The value you set to `alpha` should be greater or equal to 0 and less equal to 1:\n",
         "\n",
         "+ if `alpha` is a float between 0 and 1, we merge the weights between the pre-trained model and the fine-tuned model.\n",
         "+ if `alpha` is 0, the fine-tuned model is identical to the pre-trained model.\n",
         "+ if `alpha` is 1, the pre-trained weights will not be utilized.\n",
         "\n",
         "\n",
-        "That's it! Check out [clip-as-service](https://clip-as-service.jina.ai/user-guides/finetuner/?highlight=finetuner#fine-tune-models) to learn how to plug-in a fine-tuned CLIP model to our CLIP specific service."
+        "That's it! Check out [clip-as-service](https://clip-as-service.jina.ai/user-guides/finetuner/?highlight=finetuner#fine-tune-models) to learn how to plug in a fine-tuned CLIP model to our CLIP-specific service."
       ],
       "metadata": {
         "id": "LHyMm_M1zxdt"

--- a/docs/notebooks/text_to_image.ipynb
+++ b/docs/notebooks/text_to_image.ipynb
@@ -345,7 +345,7 @@
         ")\n",
         "```\n",
         "\n",
-        "The value you set to `alpha` should be greater or equal to 0 and less or equal to 1:\n",
+        "The value you set for `alpha` should be greater than or equal to 0 and less than or equal to 1:\n",
         "\n",
         "+ if `alpha` is a float between 0 and 1, we merge the weights between the pre-trained model and the fine-tuned model.\n",
         "+ if `alpha` is 0, the fine-tuned model is identical to the pre-trained model.\n",

--- a/docs/notebooks/text_to_image.md
+++ b/docs/notebooks/text_to_image.md
@@ -232,7 +232,7 @@ run = finetuner.fit(
 )
 ```
 
-The value you set to `alpha` should be greater or equal to 0 and less equal to 1:
+The value you set to `alpha` should be greater or equal to 0 and less or equal to 1:
 
 + if `alpha` is a float between 0 and 1, we merge the weights between the pre-trained model and the fine-tuned model.
 + if `alpha` is 0, the fine-tuned model is identical to the pre-trained model.

--- a/docs/notebooks/text_to_image.md
+++ b/docs/notebooks/text_to_image.md
@@ -232,7 +232,7 @@ run = finetuner.fit(
 )
 ```
 
-The value you set to `alpha` should be greater or equal to 0 and less or equal to 1:
+The value you set for `alpha` should be greater than or equal to 0 and less than or equal to 1:
 
 + if `alpha` is a float between 0 and 1, we merge the weights between the pre-trained model and the fine-tuned model.
 + if `alpha` is 0, the fine-tuned model is identical to the pre-trained model.

--- a/docs/notebooks/text_to_image.md
+++ b/docs/notebooks/text_to_image.md
@@ -16,11 +16,11 @@ jupyter:
 
 <a href="https://colab.research.google.com/drive/1yKnmy2Qotrh3OhgwWRsMWPFwOSAecBxg?usp=sharing"><img alt="Open In Colab" src="https://colab.research.google.com/assets/colab-badge.svg"></a>
 
-Traditionally, searching images from text (text-image-retrieval) relies heavily on human annotations, this is commonly referred to as *Text/Tag based Image Retrieval (TBIR)*.
+Traditionally, searching images from text (text-image-retrieval) relies heavily on human annotations, this is commonly referred to as *Text/Tag-based Image Retrieval (TBIR)*.
 
 The [OpenAI CLIP](https://github.com/openai/CLIP) model maps the dense vectors extracted from text and image into the same semantic space and produces a strong zero-shot model to measure the similarity between text and images.
 
-This guide will showcase fine-tuning a `CLIP` model for text to image retrieval.
+This guide will showcase fine-tuning a `CLIP` model for text-to-image retrieval.
 
 *Note, please consider switching to GPU/TPU Runtime for faster inference.*
 
@@ -35,13 +35,13 @@ This guide will showcase fine-tuning a `CLIP` model for text to image retrieval.
 ## Task
 We'll be fine-tuning CLIP on the [fashion captioning dataset](https://github.com/xuewyang/Fashion_Captioning) which contains information about fashion products.
 
-For each product the dataset contains a title and images of multiple variants of the product. We constructed a parent [`Document`](https://docarray.jina.ai/fundamentals/document/#document) for each picture, which contains two [chunks](https://docarray.jina.ai/fundamentals/document/nested/#nested-structure): an image document and a text document holding the description of the product.
+For each product, the dataset contains a title and images of multiple variants of the product. We constructed a parent [`Document`](https://docarray.jina.ai/fundamentals/document/#document) for each picture, which contains two [chunks](https://docarray.jina.ai/fundamentals/document/nested/#nested-structure): an image document and a text document holding the description of the product.
 <!-- #endregion -->
 
 <!-- #region id="EVBez7dHwIye" -->
 ## Data
 Our journey starts locally. We have to [prepare the data and push it to the Jina AI Cloud](https://finetuner.jina.ai/walkthrough/create-training-data/) and Finetuner will be able to get the dataset by its name. For this example,
-we already prepared the data, and we'll provide the names of traning and evaluation data (`fashion-train-data-clip` and `fashion-eval-data-clip`) directly to Finetuner.
+we already prepared the data, and we'll provide the names of training and evaluation data (`fashion-train-data-clip` and `fashion-eval-data-clip`) directly to Finetuner.
 In addition, we also provide labeled queries and an index of labeled documents for evaluating the retrieval capabilities of the resulting fine-tuned model stored in the datasets `fashion-eval-data-queries` and `fashion-eval-data-index`.
 
 
@@ -106,7 +106,7 @@ run = finetuner.fit(
 Let's understand what this piece of code does:
 
 * We start with providing `model`, names of training and evaluation data.
-* We also provide some hyper-parameters such as number of `epochs` and a `learning_rate`.
+* We also provide some hyperparameters such as number of `epochs` and a `learning_rate`.
 * We use `CLIPLoss` to optimize the CLIP model.
 * We use an evaluation callback, which uses the `'clip-text'` model for encoding the text queries and the `'clip-vision'` model for encoding the images in `'fashion-eval-data-index'`.
 
@@ -232,14 +232,14 @@ run = finetuner.fit(
 )
 ```
 
-The value you set to `alpha` should be greater equal than 0 and less equal than 1:
+The value you set to `alpha` should be greater or equal to 0 and less equal to 1:
 
 + if `alpha` is a float between 0 and 1, we merge the weights between the pre-trained model and the fine-tuned model.
 + if `alpha` is 0, the fine-tuned model is identical to the pre-trained model.
 + if `alpha` is 1, the pre-trained weights will not be utilized.
 
 
-That's it! Check out [clip-as-service](https://clip-as-service.jina.ai/user-guides/finetuner/?highlight=finetuner#fine-tune-models) to learn how to plug-in a fine-tuned CLIP model to our CLIP specific service.
+That's it! Check out [clip-as-service](https://clip-as-service.jina.ai/user-guides/finetuner/?highlight=finetuner#fine-tune-models) to learn how to plug in a fine-tuned CLIP model to our CLIP-specific service.
 <!-- #endregion -->
 
 <!-- #region id="tpm8eVRFX20B" -->

--- a/docs/notebooks/text_to_text.ipynb
+++ b/docs/notebooks/text_to_text.ipynb
@@ -10,9 +10,9 @@
         "\n",
         "<a href=\"https://colab.research.google.com/drive/1Ui3Gw3ZL785I7AuzlHv3I0-jTvFFxJ4_?usp=sharing\"><img alt=\"Open In Colab\" src=\"https://colab.research.google.com/assets/colab-badge.svg\"></a>\n",
         "\n",
-        "Searching large amounts of text documents with text queries is a very popular use-case and Finetuner enables you to accomplish this easily.\n",
+        "Searching large amounts of text documents with text queries is a very popular use case and Finetuner enables you to accomplish this easily.\n",
         "\n",
-        "This guide will lead you through an example use-case to show you how Finetuner can be used for text to text retrieval (Dense Retrieval).\n",
+        "This guide will lead you through an example use case to show you how Finetuner can be used for text-to-text retrieval (Dense Retrieval).\n",
         "\n",
         "*Note, please consider switching to GPU/TPU Runtime for faster inference.*\n",
         "\n",
@@ -57,7 +57,7 @@
         "\n",
         "```\n",
         "\n",
-        "We can fine-tune BERT so that questions that are duplicates of each other are represented in close proximity and questions that are not duplicates will have representations that are further apart in the embedding space. In this way, we can rank the embeddings in our search space by their proximity to the query question and return the highest ranking duplicates."
+        "We can fine-tune BERT so that questions that are duplicates of each other are represented in close proximity and questions that are not duplicates will have representations that are further apart in the embedding space. In this way, we can rank the embeddings in our search space by their proximity to the query question and return the highest-ranking duplicates."
       ]
     },
     {
@@ -68,7 +68,7 @@
       "source": [
         "## Data\n",
         "\n",
-        "We will use the [Quora Question Pairs](https://www.sbert.net/examples/training/quora_duplicate_questions/README.html?highlight=quora#dataset) dataset to show-case Finetuner for text to text search. We have already pre-processed this dataset and made it available for you to pull from Jina AI Cloud. Do this as follows:"
+        "We will use the [Quora Question Pairs](https://www.sbert.net/examples/training/quora_duplicate_questions/README.html?highlight=quora#dataset) dataset to showcase Finetuner for text-to-text search. We have already pre-processed this dataset and made it available for you to pull from Jina AI Cloud. Do this as follows:"
       ]
     },
     {
@@ -320,7 +320,7 @@
         "id": "a_vUDidVIkh7"
       },
       "source": [
-        "And finally you can use the embeded `query` to find top-k semantically related text within `index_data` as follows:"
+        "And finally, you can use the embedded `query` to find top-k semantically related text within `index_data` as follows:"
       ]
     },
     {

--- a/docs/notebooks/text_to_text.md
+++ b/docs/notebooks/text_to_text.md
@@ -16,9 +16,9 @@ jupyter:
 
 <a href="https://colab.research.google.com/drive/1Ui3Gw3ZL785I7AuzlHv3I0-jTvFFxJ4_?usp=sharing"><img alt="Open In Colab" src="https://colab.research.google.com/assets/colab-badge.svg"></a>
 
-Searching large amounts of text documents with text queries is a very popular use-case and Finetuner enables you to accomplish this easily.
+Searching large amounts of text documents with text queries is a very popular use case and Finetuner enables you to accomplish this easily.
 
-This guide will lead you through an example use-case to show you how Finetuner can be used for text to text retrieval (Dense Retrieval).
+This guide will lead you through an example use case to show you how Finetuner can be used for text-to-text retrieval (Dense Retrieval).
 
 *Note, please consider switching to GPU/TPU Runtime for faster inference.*
 
@@ -51,13 +51,13 @@ What do geologists do?
 
 ```
 
-We can fine-tune BERT so that questions that are duplicates of each other are represented in close proximity and questions that are not duplicates will have representations that are further apart in the embedding space. In this way, we can rank the embeddings in our search space by their proximity to the query question and return the highest ranking duplicates.
+We can fine-tune BERT so that questions that are duplicates of each other are represented in close proximity and questions that are not duplicates will have representations that are further apart in the embedding space. In this way, we can rank the embeddings in our search space by their proximity to the query question and return the highest-ranking duplicates.
 <!-- #endregion -->
 
 <!-- #region id="SfR6g0E_8fOz" -->
 ## Data
 
-We will use the [Quora Question Pairs](https://www.sbert.net/examples/training/quora_duplicate_questions/README.html?highlight=quora#dataset) dataset to show-case Finetuner for text to text search. We have already pre-processed this dataset and made it available for you to pull from Jina AI Cloud. Do this as follows:
+We will use the [Quora Question Pairs](https://www.sbert.net/examples/training/quora_duplicate_questions/README.html?highlight=quora#dataset) dataset to showcase Finetuner for text-to-text search. We have already pre-processed this dataset and made it available for you to pull from Jina AI Cloud. Do this as follows:
 <!-- #endregion -->
 
 ```python id="pwS11Nsg7jPM"
@@ -219,7 +219,7 @@ assert query.embeddings.shape == (1, 768)
 ```
 
 <!-- #region id="a_vUDidVIkh7" -->
-And finally you can use the embeded `query` to find top-k semantically related text within `index_data` as follows:
+And finally, you can use the embedded `query` to find top-k semantically related text within `index_data` as follows:
 <!-- #endregion -->
 
 ```python id="-_bM-TXRE2h7"

--- a/docs/walkthrough/choose-backbone.md
+++ b/docs/walkthrough/choose-backbone.md
@@ -7,7 +7,7 @@ Thereby, for most of them, Finetuner provides multiple variants, e.g., the commo
 
 Finetuner will convert these backbone models to embedding models by removing
 the *head* or applying *pooling*,
-fine-tuning and producing the final embedding model.
+performing fine-tuning and producing the final embedding model.
 The embedding model can be fine-tuned for text-to-text, image-to-image or text-to-image
 search tasks.
 
@@ -41,7 +41,7 @@ finetuner.describe_models(task='mesh-to-mesh')
 ```
 ````
 
-To get a list of supported models:
+to get a list of supported models:
 
 ````{tab} text-to-text
 ```bash
@@ -120,6 +120,6 @@ To get a list of supported models:
 
 It should be noted that:
 
-+ resnet/efficientnet models are loaded from the [torchvision](https://pytorch.org/vision/stable/index.html) library.
-+ transformer based models are loaded from the huggingface [transformers](https://github.com/huggingface/transformers) library.
++ ResNet/EfficientNet models are loaded from the [torchvision](https://pytorch.org/vision/stable/index.html) library.
++ Transformer-based models are loaded from the huggingface [transformers](https://github.com/huggingface/transformers) library.
 + `msmarco-distilbert-base-v3` has been fine-tuned once by [sentence-transformers](https://www.sbert.net/) on the [MS MARCO](https://microsoft.github.io/msmarco/) dataset on top of BERT.

--- a/docs/walkthrough/create-training-data.md
+++ b/docs/walkthrough/create-training-data.md
@@ -17,22 +17,22 @@ Currently, `excel`, `excel-tab` and `unix` CSV dialects are supported. To specif
 In cases where you want multiple elements grouped together, you can provide a label in the second column. This way, all elements in the first column that have the same label will be considered similar when training. To indicate that the second column of your CSV file represents a label instead of a second element, set `is_labeled = True` in the `csv_options` argument of the {meth}`~finetuner.fit` function. Your data can then be structured like so:
 
 ```markdown
-Hello!                  greeting-english
-Hi there.               greeting-english
-Good morning.           greeting-english
-I'm (…) sorry!          apologize-english
-I'm sorry to have…      apologize-english
-Please, forgive me!     apologize-english
+Hello!, greeting-english
+Hi there., greeting-english
+Good morning., greeting-english
+I'm (…) sorry!, apologize-english
+I'm sorry to have…, apologize-english
+Please ... forgive me!, apologize-english
 ```
 
 When using image-to-image or mesh-to-mesh retrieval models, images and meshes can be represented as a URI or a path to a file:
 
 ```markdown
-/Users/images/apples/green_apple.jpg    picture of apple
-/Users/images/apples/red_apple.jpg      picture of apple
-https://example.com/apple-styling.jpg   picture of apple
-/Users/images/oranges/orange.jpg        picture of orange
-https://example.com/orange-styling.jpg  picture of orange
+/Users/images/apples/green_apple.jpg, picture of apple
+/Users/images/apples/red_apple.jpg, picture of apple
+https://example.com/apple-styling.jpg, picture of apple
+/Users/images/oranges/orange.jpg, picture of orange
+https://example.com/orange-styling.jpg, picture of orange
 ```
 
 ```diff
@@ -61,8 +61,8 @@ Please note, that local files can not be processed by the Finetuner if you deact
 To prepare data for text-to-image search, each row must contain one URI to an image and one piece of text. The order that these two are placed does not matter, so long as the ordering is kept consistent for all rows.
 
 ```markdown
-This is a photo of an apple.                apple.jpg
-This is a black-white photo of an organge.  orange.jpg
+This is a photo of an apple., apple.jpg
+This is a black-white photo of an organge., orange.jpg
 ```
 
 ```{admonition} CLIP model explained
@@ -80,8 +80,8 @@ At the model saving time, you will discover, we are saving two models to your lo
 If you want two elements to be semantically close together, they can be placed on the same row as a pair. Each pair will automatically be assigned a distinct label:
 
 ```markdown
-This is an English sentence         Das ist ein englischer Satz
-This is another English sentence    Dies ist ein weiterer englischer Satz
+This is an English sentence, Das ist ein englischer Satz
+This is another English sentence, Dies ist ein weiterer englischer Satz
 ...
 ```
 

--- a/docs/walkthrough/create-training-data.md
+++ b/docs/walkthrough/create-training-data.md
@@ -58,7 +58,7 @@ Please note, that local files can not be processed by the Finetuner if you deact
 ````
 
 ````{tab} text-to-image search using CLIP
-To prepare data for text-to-image search, each row must contain one URI to an image and one piece of text. The order that these two are placed does not matter, so long as the ordering is kept consistent for all rows.
+To prepare data for text-to-image search, each row must contain one URI pointing to an image and one piece of text. The order that these two are placed does not matter, so long as the ordering is kept consistent for all rows.
 
 ```markdown
 This is a photo of an apple., apple.jpg

--- a/docs/walkthrough/create-training-data.md
+++ b/docs/walkthrough/create-training-data.md
@@ -104,10 +104,6 @@ We support the following dialects of CSV:
 + `excel-tab` use `\t` as delimiter and `\r\n` as lineterminator.
 + `unix` use `,` as delimiter and `\n` as lineterminator.
 
-```{warning}
-Please remove/replace commas in your data fields if you are using a comma `,` as a delimiter.
-```
-
 
 ## Preparing a DocumentArray
 When providing training data in a DocumentArray, each element is represented as a {class}`~docarray.document.Document`. You should assign a label to each {class}`~docarray.document.Document` inside your {class}`~docarray.array.document.DocumentArray`.

--- a/docs/walkthrough/create-training-data.md
+++ b/docs/walkthrough/create-training-data.md
@@ -4,7 +4,7 @@
 Finetuner accepts training data and evaluation data in the form of CSV files 
 or {class}`~docarray.array.document.DocumentArray` objects.
 Because Finetuner follows a [supervised-learning](https://en.wikipedia.org/wiki/Supervised_learning) scheme, each element requires a label that identifies which other elements it should be similar to. 
-If you need to evaluate metrics on separate evaluation data, it is recommended to create a dataset only for evaluation purposes. This can be done in the same way a a training dataset is created, as described below.
+If you need to evaluate metrics on separate evaluation data, it is recommended to create a dataset only for evaluation purposes. This can be done in the same way as a training dataset is created, as described below.
 
 Data can be prepared in two different formats, either as a CSV file, or as a {class}`~docarray.array.document.DocumentArray`. In the sections below, you can see examples which demonstrate how the training datasets should look like for each format.
 
@@ -51,19 +51,14 @@ run = finetuner.fit(
 If paths to local images are provided,
 they can be loaded into memory by setting `convert_to_blob = True` (default) in the {class}`~finetuner.data.CSVOptions` object.
 It is important to note that this setting does not cause Internet URLs to be loaded into memory.
-For 3D meshes the option `create_point_clouds` (`True` by default) creates point cloud tensors, which are used as input by the mesh encoding models.
+For 3D meshes, the option `create_point_clouds` (`True` by default) creates point cloud tensors, which are used as input by the mesh encoding models.
 Please note, that local files can not be processed by the Finetuner if you deactivate `convert_to_blob` or `create_point_clouds`.
-```
-
-```{important} 
-If the text field contains commas, it breaks the CSV format since it is interpreted as spanning over multiple columns.
-In this case, please enclose the field in double quotes, such as `field1,"field, 2"`.
 ```
 
 ````
 
 ````{tab} text-to-image search using CLIP
-To prepare data for text-to-image search, each row must contain one uri to an image, and one piece of text. The order that these two are placed does not matter, so long as the ordering is kept consistent for all rows.
+To prepare data for text-to-image search, each row must contain one URI to an image and one piece of text. The order that these two are placed does not matter, so long as the ordering is kept consistent for all rows.
 
 ```markdown
 This is a photo of an apple.                apple.jpg
@@ -82,7 +77,7 @@ At the model saving time, you will discover, we are saving two models to your lo
 
 
 ````{tab} two elements per row
-If you want two elements to be semantically close together, they can be placed on the same row as a pair, Each pair will automatically be assigned a distinct label:
+If you want two elements to be semantically close together, they can be placed on the same row as a pair. Each pair will automatically be assigned a distinct label:
 
 ```markdown
 This is an English sentence         Das ist ein englischer Satz
@@ -97,6 +92,12 @@ Some sampling methods that require more than two elements per class will not wor
 
 ````
 
+
+```{important} 
+If a text field contains commas, it breaks the CSV format since it is interpreted as spanning over multiple columns.
+In this case, please enclose the field in double quotes, such as `field1,"field, 2"`.
+```
+
 We support the following dialects of CSV:
 
 + `excel` use `,` as delimiter and `\r\n` as lineterminator.
@@ -104,7 +105,7 @@ We support the following dialects of CSV:
 + `unix` use `,` as delimiter and `\n` as lineterminator.
 
 ```{warning}
-Please remove/replace comma in your data fields if you are using a comma `,` as a delimiter.
+Please remove/replace commas in your data fields if you are using a comma `,` as a delimiter.
 ```
 
 
@@ -112,9 +113,9 @@ Please remove/replace comma in your data fields if you are using a comma `,` as 
 When providing training data in a DocumentArray, each element is represented as a {class}`~docarray.document.Document`. You should assign a label to each {class}`~docarray.document.Document` inside your {class}`~docarray.array.document.DocumentArray`.
 For most of the models, this is done by adding a `finetuner_label` tag to each document.
 Only for cross-modality (text-to-image) fine-tuning with CLIP, is this not necessary as explained at the bottom of this section.
-{class}`~docarray.document.Document`s containing uris that point to local images can load these images into memory using the {meth}`docarray.document.Document.load_uri_to_blob` function of that {class}`~docarray.document.Document`.
-Similarly, {class}`~docarray.document.Document`s with uris of local 3D meshes, can be converted into point clouds which are stored in the Document by calling {meth}`docarray.document.Document.load_uri_to_point_cloud_tensor`.
-The function requires a number of points, which we recommend to set to 2048.
+{class}`~docarray.document.Document`s containing URIs that point to local images can load these images into memory using the {meth}`docarray.document.Document.load_uri_to_blob` function of that {class}`~docarray.document.Document`.
+Similarly, {class}`~docarray.document.Document`s with URIs of local 3D meshes, can be converted into point clouds which are stored in the Document by calling {meth}`docarray.document.Document.load_uri_to_point_cloud_tensor`.
+The function requires a number of points, which we recommend setting to 2048.
 
 
 ````{tab} text-to-text search

--- a/docs/walkthrough/index.md
+++ b/docs/walkthrough/index.md
@@ -13,8 +13,8 @@ this model on your dataset.
 
 Once fine-tuning is done, you get a model adapted to your domain. This new model leverages better search performance on your-task-of-interest.
 
-Fine-tuning a pre-trained model includes a certain complexity and requires Machine Learning plus domain knowledge (on NLP, Computer Vision e.t.c).
-Thus, it is a non-trivial task for business owners and engineers who lack the practical deep learning knowledge. Finetuner attempts
+Fine-tuning a pre-trained model includes a certain complexity and requires Machine Learning plus domain knowledge (on NLP, Computer Vision, etc.).
+Thus, it is a non-trivial task for business owners and engineers who lack practical deep-learning knowledge. Finetuner attempts
 to address this by providing a simple interface, which can be as easy as:
 
 ```python

--- a/docs/walkthrough/inference.md
+++ b/docs/walkthrough/inference.md
@@ -1,7 +1,7 @@
 # Inference
 
 Once fine-tuning is finished, it's time to actually use the model.
-You can use the fine-tuned models directly to encode [DocumentArray](https://docarray.jina.ai/) objects or set up an encoding service.
+You can use the fine-tuned models directly to encode [DocumentArray](https://docarray.jina.ai/) objects or to set up an encoding service.
 When encoding, data can also be provided as a regular list.
 
 ```{admonition} Use FinetunerExecutor inside a Jina Flow

--- a/docs/walkthrough/inference.md
+++ b/docs/walkthrough/inference.md
@@ -1,7 +1,7 @@
 # Inference
 
 Once fine-tuning is finished, it's time to actually use the model.
-You can use the fine-tuned models directly to encode [DocumentArray](https://docarray.jina.ai/) objects or setting up an encoding service.
+You can use the fine-tuned models directly to encode [DocumentArray](https://docarray.jina.ai/) objects or set up an encoding service.
 When encoding, data can also be provided as a regular list.
 
 ```{admonition} Use FinetunerExecutor inside a Jina Flow
@@ -13,7 +13,9 @@ If you would like to use fine-tuned model inside a Jina Flow as an Executor, che
 
 (integrate-with-list)=
 ## Encoding a List
-Data that is stored in a regular list can be embedded in the same way you would a [DocumentArray](https://docarray.jina.ai/). Since the modality of your input data can be inferred from the model being used, there is no need to provide any additional information besides the content you want to encode. When providing data as a list, the `finetuner.encode` method will return a `np.ndarray` of embeddings, instead of a `docarray.DocumentArray`:
+Data that is stored in a regular list can be embedded in the same way you would embed a [DocumentArray](https://docarray.jina.ai/).
+Since the modality of your input data can be inferred from the model being used, there is no need to provide any additional information besides the content you want to encode.
+When providing data as a list, the `finetuner.encode` method will return a `np.ndarray` of embeddings, instead of a `docarray.DocumentArray`:
 
 ````{tab} Artifact id and token
 ```python
@@ -87,14 +89,14 @@ for text, embedding in zip(texts, embeddings):
 ```{admonition} Inference with ONNX
 :class: tip
 In case you set `to_onnx=True` when calling `finetuner.fit` function,
-please use `model = finetuner.get_model('/path/to/YOUR-MODEL.zip', is_onnx=True)`
+please use `model = finetuner.get_model('/path/to/YOUR-MODEL.zip', is_onnx=True)`.
 ```
 
 ```{admonition} Encoding other Modalities
 :class: tip
 Of course you can not only encode texts.
-For encoding a list of images, you can provide uris, e.g.,
-`embeddings = finetuner.encode(model=model, data=['path/to/apple.png'])`
+For encoding a list of images, you can provide URIs, e.g.,
+`embeddings = finetuner.encode(model=model, data=['path/to/apple.png'])`.
 ```
 
 (integrate-with-docarray)=

--- a/docs/walkthrough/login.md
+++ b/docs/walkthrough/login.md
@@ -19,7 +19,7 @@ After {meth}`~finetuner.login()` you will see the following message in your term
 ```
 
  Now, an authentication token is generated which can be read with the {func}`~finetuner.get_token` function.
-If you have been logged in before, the existing token will not be overwritten, however, if you want this to be happen, you can set the `force` attribute in the login function to true.
+If you have been logged in before, the existing token will not be overwritten, however, if you want this to happen, you can set the `force` attribute in the login function to true.
 
 ```
 finetuner.login(force=True)

--- a/docs/walkthrough/run-job.md
+++ b/docs/walkthrough/run-job.md
@@ -24,7 +24,7 @@ print(f'Run name: {run.name}')
 print(f'Run status: {run.status()}')
 ```
 
-You'll see something like this in the terminal, with a different run name:
+You'll see something like this in the terminal with a different run name:
 
 ```bash
 Run name: vigilant-tereshkova
@@ -88,7 +88,7 @@ The type of loss function which is most suitable for your task depends heavily o
 For many retrieval tasks, the `TripletMarginLoss` is a good choice.
 
 ```{Important}
-Please check the [developer reference](../../api/finetuner/#finetuner.fit) to get the available options for `loss`, `miner`, `optimizer` and `scheduler_step`.
+Please check the [developer reference](../../api/finetuner/#finetuner.fit) to get the available options for `loss`, `miner`, `optimizer`, and `scheduler_step`.
 ```
 
 ### Configuration of the optimizer

--- a/docs/walkthrough/save-model.md
+++ b/docs/walkthrough/save-model.md
@@ -13,7 +13,7 @@ Each model has a artifact id, which is sufficient to setup an encoding serivce a
 Alternatively, you can also download the model using the artifact id, as explained below, e.g., to use it in a locally runnig Jina service. 
 ```
 
-Please note that fine-tuning takes time. It highly depends on the size of your training data, evaluation data and other hyper-parameters.
+Please note that fine-tuning takes time. It highly depends on the size of your training data, evaluation data, and other hyperparameters.
 Because of this, you might have to close the session and reconnect to it several times.
 
 In the example below, we show how to connect to an existing run and download a tuned model:
@@ -60,12 +60,10 @@ run.save_artifact('tuned_model')
 :class: hint
 Finetuner allows you to set your artifact as a public artifact.
 At training time, you need to set `public=True` when calling the `fit` function.
-
-If `public=True`, anyone has the same artifact id can download your artifact with the above function.
+If `public=True`, anyone who knows the artifact id can download your artifact with the above function.
 ```
 
-If the fine-tuning finished,
-you can see the following message in the terminal:
+If the fine-tuning finished, you can see the following message in the terminal:
 
 ```bash
 🔐 Successfully logged in to Jina AI as [USER NAME]!

--- a/docs/walkthrough/save-model.md
+++ b/docs/walkthrough/save-model.md
@@ -63,7 +63,7 @@ At training time, you need to set `public=True` when calling the `fit` function.
 If `public=True`, anyone who knows the artifact id can download your artifact with the above function.
 ```
 
-If the fine-tuning finished, you can see the following message in the terminal:
+If the fine-tuning is finished, you will see the following message in the terminal:
 
 ```bash
 🔐 Successfully logged in to Jina AI as [USER NAME]!


### PR DESCRIPTION
Fix typos and duplicate text in docs
---

I removed the duplicate part in the documentation and fixed a couple of typos and minor wrong formulations.

- [ ] This PR references an open issue
- [x] I have added a line about this change to CHANGELOG