### PR TITLE
docs: add section about articles about finetuner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix typos, duplicate paragraphs, and wrong formulations. ([#666](https://github.com/jina-ai/finetuner/pull/666)) 
 
+- Add list of articles to README and docs. ([#669](https://github.com/jina-ai/finetuner/pull/669))
+
 
 ## [0.7.0] - 2023-01-18
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,18 @@ pip install "finetuner[full]"
 > ⚠️ Starting with version 0.5.0, Finetuner computing is performed on Jina AI Cloud. The last local version is `0.4.1`. 
 > This version is still available for installation via `pip`. See [Finetuner git tags and releases](https://github.com/jina-ai/finetuner/releases).
 
+<!-- start finetuner-articles -->
+## Articles about Finetuner
+
+There are several articles about Finetuner and tutorials which using our framework:
+
+- [Fine-tuning with Low Budget and High Expectations](https://jina.ai/news/fine-tuning-with-low-budget-and-high-expectations/)
+- [Hype and Hybrids: Search is more than Keywords and Vectors](https://jina.ai/news/hype-and-hybrids-multimodal-search-means-more-than-keywords-and-vectors-2/)
+- [Improving Search Quality for Non-English Queries with Fine-tuned Multilingual CLIP Models](https://jina.ai/news/improving-search-quality-non-english-queries-fine-tuned-multilingual-clip-models/)
+- [How Much Do We Get by Finetuning CLIP?](https://jina.ai/news/applying-jina-ai-finetuner-to-clip-less-data-smaller-models-higher-performance/)
+
+<!-- end finetuner-articles -->
+
 <!-- start support-pitch -->
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ pip install "finetuner[full]"
 <!-- start finetuner-articles -->
 ## Articles about Finetuner
 
-There are several articles about Finetuner and tutorials which using our framework:
+We wrote several articles and tutorials in which our framework is used:
 
 - [Fine-tuning with Low Budget and High Expectations](https://jina.ai/news/fine-tuning-with-low-budget-and-high-expectations/)
 - [Hype and Hybrids: Search is more than Keywords and Vectors](https://jina.ai/news/hype-and-hybrids-multimodal-search-means-more-than-keywords-and-vectors-2/)

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ pip install "finetuner[full]"
 <!-- start finetuner-articles -->
 ## Articles about Finetuner
 
-We wrote several articles and tutorials in which our framework is used:
+Check out our published blogposts and tutorials to see Finetuner in action!
 
 - [Fine-tuning with Low Budget and High Expectations](https://jina.ai/news/fine-tuning-with-low-budget-and-high-expectations/)
 - [Hype and Hybrids: Search is more than Keywords and Vectors](https://jina.ai/news/hype-and-hybrids-multimodal-search-means-more-than-keywords-and-vectors-2/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,11 @@
 ```
 
 ```{include} ../README.md
+:start-after: <!-- start finetuner-articles -->
+:end-before: <!-- end finetuner-articles -->
+```
+
+```{include} ../README.md
 :start-after: <!-- start support-pitch -->
 :end-before: <!-- end support-pitch -->
 ```


### PR DESCRIPTION
Add section about articles about finetuner
---

just add a section to the Readme and the docs which reference the blog posts about finetuner. If you have more to reference, let me know.

- [ ] This PR references an open issue
- [x] I have added a line about this change to CHANGELOG