### PR TITLE
docs: Add documentation for GeM pooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add notebook to demonstrate use of `ArcFaceLoss`. ([#680](https://github.com/jina-ai/finetuner/pull/680))
 
+- Add section on GeM pooling to advanced topics. ([#684](https://github.com/jina-ai/finetuner/pull/684))
+
 
 ## [0.7.1] - 2023-02-15
 

--- a/docs/advanced-topics/advanced-losses-optimizers-and-poolers.md
+++ b/docs/advanced-topics/advanced-losses-optimizers-and-poolers.md
@@ -80,7 +80,7 @@ with `TripletMarginLoss` sperarating them the least, and `ArcFaceLoss` separatin
 
 ## Pooling layers
 
-Pooling layers are layers in a machine learning model that are used to reduce the dimensionality of data. This is usually done for one of two reasons: to remove unnecessary information contained within an embedding of a larger size, or when a model outputs multiple embeddings and only one embedding is needed. Typically this is done in two ways, average pooling or max pooling.
+Pooling layers are layers in a machine learning model that are used to reduce the dimensionality of data. This is usually done for one of two reasons: to remove unnecessary information contained within an embedding of a larger size, or when a model outputs multiple embeddings and only one embedding is needed. Typically, there are two ways to do this: average pooling or max pooling.
 While a model may have many pooling layers within it, it is unwise to replace a pooling layer with another unless it is the last layer of the model.
 
 ### GeM pooling

--- a/docs/advanced-topics/advanced-losses-optimizers-and-poolers.md
+++ b/docs/advanced-topics/advanced-losses-optimizers-and-poolers.md
@@ -1,5 +1,5 @@
 (advanced-losses-optimizers-poolers)=
-# {octicon}`mortar-board` Advanced losses and optimizers
+# {octicon}`mortar-board` Advanced losses, optimizers and poolers
 Many of the models supported by Finetuner use of similar methods during finetuning, like methods for *calculating loss*, *sampling* and *pooling* . Finetuner offers alternative methods for each of these tasks, and in some cases, choosing specific methods can improve Finetuner performance.
 
 ## Loss functions
@@ -78,12 +78,30 @@ Each color represents a different class. You can see how all of the loss functio
 but struggle to separate the green, blue, pink, purple and red classes,
 with `TripletMarginLoss` sperarating them the least, and `ArcFaceLoss` separating them the most.
 
-### Choosing an optimizer
+## Pooling layers
 
-While `ArcFaceLoss` and `CosFaceLoss` are capable of outperforming `TripletMarginLoss`, There are some cases where the opposite is the case.  
-In cases where each class contains very few examples of each class, but many classes, `ArcFaceLoss` and `CosFaceLoss` struggle to separate every class,
-and doesn't perform as well as `TripletMarginLss`.  
-Another case where `ArcFaceLoss` and `CosFaceLoss` struggle is when attempting to embed documents of a class they were not trained on. 
-Since these loss functions operate by creating centroids, and then attempting to 'classify' input documents by embedding them in a space close to a centroid, 
-data that does not belong to a class with an existing centroid may erroneously be given an embedding similar to that of a class it does not belong to.  
-In cases such as these, `TripletMarginLoss` may result in a greater improvement in performance thatn `ArcFaceLoss` or `CosFaceLoss`.
+Pooling layers are layers in a machine learning model that are used to reduce the dimensionality of data. This is usually done for one of two reasons: to remove unnecessary information contained within an embedding of a larger size, or when a model outputs multiple embeddings and only one embedding is needed. Typically this is done in two ways, average pooling or max pooling.
+While a model may have many pooling layers within it, it is unwise to replace a pooling layer with another unless it is the last layer of the model.
+
+### GeM pooling
+
+`GeM` (Generalised Mean) pooling is an advanced pooling technique that has found popularity in computer vision and face recognition tasks.
+In cases where your chosen model does have a pooling layer as its last layer, Finetuner allows you to replace the default pooler with a `GeM` pooling layer.
+Currently, all of our `text-to-text` and `image-to-image` models support replacing the pooling layer.
+For a list of all models that fit these categroies, see the [Backbone Model](../walkthrough/choose-backbone.md) section.  
+
+The `GeM` pooler has two adjustable parameters, a scaling parameter `p` and an epsilon `eps`.
+At `p = 1`, the `GeM` pooler will act like an average pooler.
+As `p` increases, more weight is given to larger values, making it act more like max pooling.
+`eps` is used to clamp values to be slightly above 0, altering this won't result in much change to the performance.
+By default, `p=3` and `eps=1e-6`, you can specify the pooler and adjust these parameters in a dictionary provided to the `model_options` parameter:
+```diff
+run = finetuner.fit(
+    ...,
+    model_options = {
+        ...
++       'pooler': 'GeM',
++       'pooler_options': {'p': 2.4, 'eps': 1e-5}
+    }
+)
+```

--- a/docs/advanced-topics/advanced-losses-optimizers-and-poolers.md
+++ b/docs/advanced-topics/advanced-losses-optimizers-and-poolers.md
@@ -1,5 +1,5 @@
 (advanced-losses-optimizers-poolers)=
-# {octicon}`mortar-board` Advanced losses, optimizers and poolers
+# {octicon}`mortar-board` Advanced loss functions, optimizers and poolers
 Many of the models supported by Finetuner use of similar methods during finetuning, like methods for *calculating loss*, *sampling* and *pooling* . Finetuner offers alternative methods for each of these tasks, and in some cases, choosing specific methods can improve Finetuner performance.
 
 ## Loss functions
@@ -85,16 +85,16 @@ While a model may have many pooling layers within it, it is unwise to replace a 
 
 ### GeM pooling
 
-`GeM` (Generalised Mean) pooling is an advanced pooling technique that has found popularity in computer vision and face recognition tasks.
+`GeM` (Generalised Mean) pooling is an advanced pooling technique that is popular for computer vision and face recognition tasks.
 In cases where your chosen model does have a pooling layer as its last layer, Finetuner allows you to replace the default pooler with a `GeM` pooling layer.
 Currently, all of our `text-to-text` and `image-to-image` models support replacing the pooling layer.
-For a list of all models that fit these categroies, see the [Backbone Model](../walkthrough/choose-backbone.md) section.  
+For a list of all models that support replacing the pooling layer, see the [Backbone Model](../walkthrough/choose-backbone.md) section.  
 
-The `GeM` pooler has two adjustable parameters, a scaling parameter `p` and an epsilon `eps`.
+The `GeM` pooler has two adjustable parameters: a scaling parameter `p` and an epsilon `eps`.
 At `p = 1`, the `GeM` pooler will act like an average pooler.
 As `p` increases, more weight is given to larger values, making it act more like max pooling.
-`eps` is used to clamp values to be slightly above 0, altering this won't result in much change to the performance.
-By default, `p=3` and `eps=1e-6`, you can specify the pooler and adjust these parameters in a dictionary provided to the `model_options` parameter:
+`eps` is used to clamp values to be slightly above 0, and altering this won't result in much change to the performance.
+By default, `p=3` and `eps=1e-6`. You can specify the pooler and adjust these parameters in a dictionary provided to the `model_options` parameter:
 ```diff
 run = finetuner.fit(
     ...,

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ advanced-topics/budget
 advanced-topics/negative-mining
 advanced-topics/using-callbacks
 advanced-topics/linear-probe
-advanced-topics/advanced-losses-and-optimizers
+advanced-topics/advanced-losses-optimizers-and-poolers
 advanced-topics/finetuner-executor
 ```
 


### PR DESCRIPTION
This pr adds the section on GeM pooling that was previously removed


---

- [ ] This PR references an open issue
- [x] I have added a line about this change to CHANGELOG