### PR TITLE
chore: support python3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,10 @@ jobs:
       - name: Install client
         run: pip install 'finetuner[full]' --no-cache-dir
       - name: Check installation
-        run: python -c "import finetuner"
+        run: |
+          pip freeze | grep finetuner
+          python -c "import finetuner"
+          python -c "import torch"
 
   # just for blocking the merge until all parallel core-test are successful
   success-all-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [3.8, 3.9, 3.11]
+        version: [3.8, 3.9, 3.10.10]
     steps:
       - name: Setp up python version
         uses: actions/setup-python@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,19 @@ jobs:
       - name: Run tests
         run: make test
 
+  check-versions:
+    name: Check Python Versions
+    strategy:
+      matrix:
+        version: [3.8, 3.9, 3.11]
+      steps:
+        - name: Setp up python version
+          uses: actions/setup-python@v2
+          with:
+            python-version: ${{ matrix.version }}
+        - name: Install client
+          run: pip install 'finetuner[full]'
+
   # just for blocking the merge until all parallel core-test are successful
   success-all-test:
     needs: run-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,13 +41,13 @@ jobs:
     strategy:
       matrix:
         version: [3.8, 3.9, 3.11]
-      steps:
-        - name: Setp up python version
-          uses: actions/setup-python@v2
-          with:
-            python-version: ${{ matrix.version }}
-        - name: Install client
-          run: pip install 'finetuner[full]'
+    steps:
+      - name: Setp up python version
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.version }}
+      - name: Install client
+        run: pip install 'finetuner[full]'
 
   # just for blocking the merge until all parallel core-test are successful
   success-all-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,9 @@ jobs:
         with:
           python-version: ${{ matrix.version }}
       - name: Install client
-        run: pip install 'finetuner[full]'
+        run: pip install 'finetuner[full]' --no-cache-dir
+      - name: Check installation
+        run: python -c "import finetuner"
 
   # just for blocking the merge until all parallel core-test are successful
   success-all-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
 
   check-versions:
     name: Check Python Versions
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         version: [3.8, 3.9, 3.11]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [3.8, 3.9, 3.10.10]
+        version: [3.8, 3.9, '3.10']
     steps:
       - name: Setp up python version
         uses: actions/setup-python@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add support for python 3.11. ([#704](https://github.com/jina-ai/finetuner/pull/704))
+- Add support for python 3.10. ([#704](https://github.com/jina-ai/finetuner/pull/704))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add support for python 3.11. ([#704](https://github.com/jina-ai/finetuner/pull/704))
+
 ### Removed
 
 ### Changed

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ if __name__ == '__main__':
             'Intended Audience :: Science/Research',
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
+            'Programming Language :: Python :: 3.11',
             'License :: OSI Approved :: Apache Software License',
             'Environment :: Console',
             'Operating System :: OS Independent',

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ if __name__ == '__main__':
             'Intended Audience :: Science/Research',
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
-            'Programming Language :: Python :: 3.11',
+            'Programming Language :: Python :: 3.10',
             'License :: OSI Approved :: Apache Software License',
             'Environment :: Console',
             'Operating System :: OS Independent',


### PR DESCRIPTION
This pr adds support for python 3.10, as well as adding a test to the ci that attempts to install finetuner for all supported versions. Currently, we cannot support python 3.11 as it is not supported by ONNX runtime

---

- [ ] This PR references an open issue
- [x] I have added a line about this change to CHANGELOG