### PR TITLE
feat: add error message when experiment is `None`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add support for python 3.10. ([#704](https://github.com/jina-ai/finetuner/pull/704))
 
+- Add error message when `experiment` is `None` when creating a run. ([#708](https://github.com/jina-ai/finetuner/pull/708))
+
 ### Removed
 
 ### Changed

--- a/finetuner/finetuner.py
+++ b/finetuner/finetuner.py
@@ -188,8 +188,8 @@ class Finetuner:
         if not experiment:
             raise ValueError(
                 (
-                    'unable to start finetuning run as experiment is `None`. '
-                    'make sure you have logged in using `finetuner.login()`.'
+                    'Unable to start finetuning run as experiment is `None`. '
+                    'Make sure you have logged in using `finetuner.login()`.'
                 )
             )
         return experiment.create_run(

--- a/finetuner/finetuner.py
+++ b/finetuner/finetuner.py
@@ -185,6 +185,13 @@ class Finetuner:
             experiment = self._default_experiment
         else:
             experiment = self.get_experiment(name=experiment_name)
+        if not experiment:
+            raise ValueError(
+                (
+                    'unable to start finetuning run as experiment is `None`. '
+                    'make sure you have logged in using `finetuner.login()`.'
+                )
+            )
         return experiment.create_run(
             model=model,
             train_data=train_data,

--- a/finetuner/finetuner.py
+++ b/finetuner/finetuner.py
@@ -189,7 +189,7 @@ class Finetuner:
             raise ValueError(
                 (
                     'Unable to start finetuning run as experiment is `None`. '
-                    'Make sure you have logged in using `finetuner.login()`.'
+                    'Make sure you have logged in using `finetuner.login(force=True)`.'
                 )
             )
         return experiment.create_run(


### PR DESCRIPTION
This pr checks if `experiment` has successfully been set before starting a run, and will raise a ValueError if not.

---

- [ ] This PR references an open issue
- [x] I have added a line about this change to CHANGELOG