### PR TITLE
fix: reduce flakiness of tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix error caused by pods restarting. ([#709](https://github.com/jina-ai/finetuner/pull/709))
+
 ### Docs
 
 

--- a/finetuner/client/base.py
+++ b/finetuner/client/base.py
@@ -2,6 +2,7 @@ import os
 from typing import List, Optional, Union
 
 import requests
+from requests.adapters import HTTPAdapter, Retry
 
 import hubble
 from finetuner.client.session import _HeaderPreservingSession
@@ -40,6 +41,8 @@ class _BaseClient:
     @staticmethod
     def _get_client_session() -> _HeaderPreservingSession:
         session = _HeaderPreservingSession(trusted_domains=[])
+        retries = Retry(total=1)
+        session.mount('http://', HTTPAdapter(max_retries=retries))
         api_token = TOKEN_PREFIX + str(hubble.Auth.get_auth_token())
         session.headers.update({CHARSET: UTF_8, AUTHORIZATION: api_token})
         return session

--- a/finetuner/client/base.py
+++ b/finetuner/client/base.py
@@ -2,7 +2,6 @@ import os
 from typing import List, Optional, Union
 
 import requests
-from requests.adapters import HTTPAdapter, Retry
 
 import hubble
 from finetuner.client.session import _HeaderPreservingSession
@@ -41,8 +40,6 @@ class _BaseClient:
     @staticmethod
     def _get_client_session() -> _HeaderPreservingSession:
         session = _HeaderPreservingSession(trusted_domains=[])
-        retries = Retry(total=1)
-        session.mount('http://', HTTPAdapter(max_retries=retries))
         api_token = TOKEN_PREFIX + str(hubble.Auth.get_auth_token())
         session.headers.update({CHARSET: UTF_8, AUTHORIZATION: api_token})
         return session

--- a/finetuner/client/base.py
+++ b/finetuner/client/base.py
@@ -58,6 +58,7 @@ class _BaseClient:
         params: Optional[dict] = None,
         json_data: Optional[dict] = None,
         stream: bool = False,
+        timeout: Optional[int] = None,
     ) -> Union[dict, List[dict], str, requests.Response]:
         """The base request handler.
 
@@ -75,6 +76,7 @@ class _BaseClient:
             params=params,
             allow_redirects=True,
             stream=stream,
+            timeout=timeout,
         )
         if not response.ok:
             raise FinetunerServerError(

--- a/finetuner/client/client.py
+++ b/finetuner/client/client.py
@@ -175,7 +175,6 @@ class FinetunerV1Client(_BaseClient):
         # In the event that the request times out, attempt the request one more time.
         except ReadTimeout:
             response = self._handle_request(url=url, method=GET, timeout=10)
-            raise ValueError('Successfully handled timeout')
         return response
 
     def get_run_logs(self, experiment_name: str, run_name: str) -> str:


### PR DESCRIPTION
This pr attempts to prevent tests in `integration/test_runs.py` from failing at random. The current causes for failure are outlined in the linked issue.

---

- [x] This PR references an open issue
- [ ] I have added a line about this change to CHANGELOG