### PR TITLE
refactor: import DocumentArray from finetuner

### DIFF
--- a/docs/notebooks/image_to_image.ipynb
+++ b/docs/notebooks/image_to_image.ipynb
@@ -74,7 +74,7 @@
       "outputs": [],
       "source": [
         "import finetuner\n",
-        "from docarray import DocumentArray, Document\n",
+        "from finetuner import DocumentArray, Document\n",
         "\n",
         "finetuner.login(force=True)"
       ]

--- a/docs/notebooks/image_to_image.md
+++ b/docs/notebooks/image_to_image.md
@@ -54,7 +54,7 @@ Important: If your documents refer to locally stored images, please call `doc.lo
 
 ```python id="L0NfPGbTkNsc"
 import finetuner
-from docarray import DocumentArray, Document
+from finetuner import DocumentArray, Document
 
 finetuner.login(force=True)
 ```

--- a/docs/notebooks/image_to_image_arcface.ipynb
+++ b/docs/notebooks/image_to_image_arcface.ipynb
@@ -77,7 +77,7 @@
       "outputs": [],
       "source": [
         "import finetuner\n",
-        "from docarray import DocumentArray, Document\n",
+        "from finetuner import DocumentArray, Document\n",
         "\n",
         "finetuner.login(force=True)"
       ]

--- a/docs/notebooks/image_to_image_arcface.md
+++ b/docs/notebooks/image_to_image_arcface.md
@@ -57,7 +57,7 @@ Important: If your documents refer to locally stored images, please call `doc.lo
 
 ```python id="L0NfPGbTkNsc"
 import finetuner
-from docarray import DocumentArray, Document
+from finetuner import DocumentArray, Document
 
 finetuner.login(force=True)
 ```

--- a/docs/notebooks/mesh_to_mesh.ipynb
+++ b/docs/notebooks/mesh_to_mesh.ipynb
@@ -83,7 +83,7 @@
       "outputs": [],
       "source": [
         "import finetuner\n",
-        "from docarray import DocumentArray, Document\n",
+        "from finetuner import DocumentArray, Document\n",
         "\n",
         "finetuner.login(force=True)"
       ]

--- a/docs/notebooks/mesh_to_mesh.md
+++ b/docs/notebooks/mesh_to_mesh.md
@@ -58,7 +58,7 @@ The code below loads the data and prints a summary of the training datasets:
 
 ```python id="uTDreSwfYGOR"
 import finetuner
-from docarray import DocumentArray, Document
+from finetuner import DocumentArray, Document
 
 finetuner.login(force=True)
 ```

--- a/docs/notebooks/multilingual_text_to_image.ipynb
+++ b/docs/notebooks/multilingual_text_to_image.ipynb
@@ -93,7 +93,7 @@
       "outputs": [],
       "source": [
         "import finetuner\n",
-        "from docarray import DocumentArray, Document\n",
+        "from finetuner import DocumentArray, Document\n",
         "\n",
         "finetuner.login(force=True)"
       ]

--- a/docs/notebooks/multilingual_text_to_image.md
+++ b/docs/notebooks/multilingual_text_to_image.md
@@ -55,7 +55,7 @@ We will use the `DE-Fashion-Image-Text-Multimodal-train` dataset, which we have 
 
 ```python id="4420a4ac-531a-4db3-af75-ebb58d8f828b"
 import finetuner
-from docarray import DocumentArray, Document
+from finetunerr import DocumentArray, Document
 
 finetuner.login(force=True)
 ```

--- a/docs/notebooks/text_to_image.ipynb
+++ b/docs/notebooks/text_to_image.ipynb
@@ -81,7 +81,7 @@
       "cell_type": "code",
       "source": [
         "import finetuner\n",
-        "from docarray import DocumentArray, Document\n",
+        "from finetuner import DocumentArray, Document\n",
         "\n",
         "finetuner.login(force=True)"
       ],

--- a/docs/notebooks/text_to_image.md
+++ b/docs/notebooks/text_to_image.md
@@ -53,7 +53,7 @@ When working with documents where images are stored locally, please call `doc.lo
 
 ```python id="vfPZBQVxxEHm"
 import finetuner
-from docarray import DocumentArray, Document
+from finetuner import DocumentArray, Document
 
 finetuner.login(force=True)
 ```

--- a/docs/notebooks/text_to_text.ipynb
+++ b/docs/notebooks/text_to_text.ipynb
@@ -80,7 +80,7 @@
       "outputs": [],
       "source": [
         "import finetuner\n",
-        "from docarray import DocumentArray, Document\n",
+        "from finetuner import DocumentArray, Document\n",
         "\n",
         "finetuner.login(force=True)\n"
       ]

--- a/docs/notebooks/text_to_text.md
+++ b/docs/notebooks/text_to_text.md
@@ -62,7 +62,7 @@ We will use the [Quora Question Pairs](https://www.sbert.net/examples/training/q
 
 ```python id="pwS11Nsg7jPM"
 import finetuner
-from docarray import DocumentArray, Document
+from finetuner import DocumentArray, Document
 
 finetuner.login(force=True)
 

--- a/docs/walkthrough/create-training-data.md
+++ b/docs/walkthrough/create-training-data.md
@@ -120,17 +120,21 @@ We support the following dialects of CSV:
 
 
 ## Preparing a DocumentArray
-When providing training data in a DocumentArray, each element is represented as a {class}`~docarray.document.Document`. You should assign a label to each {class}`~docarray.document.Document` inside your {class}`~docarray.array.document.DocumentArray`.
+Internally, Finetuner stores all training data as {class}`~docarray.document.DocumentArray`s.
+When providing training data in a DocumentArray, each element is represented as a {class}`~docarray.document.Document`
+You should assign a label to each {class}`~docarray.document.Document` inside your {class}`~docarray.document.DocumentArray`.
 For most of the models, this is done by adding a `finetuner_label` tag to each document.
-Only for cross-modality (text-to-image) fine-tuning with CLIP, is this not necessary as explained at the bottom of this section.
-{class}`~docarray.document.Document`s containing URIs that point to local images can load these images into memory using the {meth}`docarray.document.Document.load_uri_to_blob` function of that {class}`~docarray.document.Document`.
-Similarly, {class}`~docarray.document.Document`s with URIs of local 3D meshes, can be converted into point clouds which are stored in the Document by calling {meth}`docarray.document.Document.load_uri_to_point_cloud_tensor`.
+Only for cross-modality (text-to-image) fine-tuning with CLIP, is this not necessary as explained at the bottom of this section.  
+{class}`~docarray.document.Document`s containing URIs that point to local images can load these images into memory
+using the {meth}`docarray.document.Document.load_uri_to_blob` function of that {class}`~docarray.document.Document`.
+Similarly, {class}`~docarray.document.Document`s with URIs of local 3D meshes can be converted into point
+clouds which are stored in the Document by calling {meth}`docarray.document.Document.load_uri_to_point_cloud_tensor`.
 The function requires a number of points, which we recommend setting to 2048.
 
 
 ````{tab} text-to-text search
 ```python
-from docarray import Document, DocumentArray
+from finetunerrr import Document, DocumentArray
 
 train_da = DocumentArray([
     Document(
@@ -147,7 +151,7 @@ train_da = DocumentArray([
 ````
 ````{tab} similarity scores
 ```python
-from docarray import Document, DocumentArray
+from finetuner import Document, DocumentArray
 
 train_da = DocumentArray([
     Document(
@@ -170,7 +174,7 @@ train_da = DocumentArray([
 ````
 ````{tab} image-to-image search
 ```python
-from docarray import Document, DocumentArray
+from finetuner import Document, DocumentArray
 
 train_da = DocumentArray([
     Document(
@@ -187,7 +191,7 @@ train_da = DocumentArray([
 ````
 ````{tab} mesh-to-mesh search
 ```python
-from docarray import Document, DocumentArray
+from finetuner import Document, DocumentArray
 
 train_da = DocumentArray([
     Document(
@@ -204,7 +208,7 @@ train_da = DocumentArray([
 ````
 ````{tab} text-to-image search on CLIP
 ```python
-from docarray import Document, DocumentArray
+from finetunerr import Document, DocumentArray
 
 train_da = DocumentArray([
     Document(
@@ -245,3 +249,39 @@ The image and text form a pair.
 During the training, CLIP learns to place documents that are part of a pair close to
 each other and documents that are not part of a pair far from each other.
 As a result, no further labels need to be provided.
+
+### Pushing and Pulling DocumentArrays
+You can store a {class}`~docarray.document.DocumentArray` on the Jina AI Cloud using the
+{meth}`docarray.document.Document.push` function:
+
+```python
+from finetuner import Document, DocumentArray
+train_da = DocumentArray([
+    Document(
+        content='pencil skirt slim fit available for sell',
+        tags={'finetuner_label': 'skirt'}
+    ),
+    Document(
+        content='stripped over-sized shirt for sell',
+        tags={'finetuner_label': 't-shirt'}
+    ),
+    ...,
+])
+train_da.push('my_train_da', public=True)
+```
+Setting `public` to `True` means that other users will be able to retrive your {class}`~docarray.document.DocumentArray`.  
+To retrieve a {class}`~docarray.document.DocumentArray` from the Jina AI Cloud, you can use the {meth}`~docarray.document.DocumentArray.pull`:
+```python
+from finetuner import DocumentArray
+
+my_data = DocumentArray.pull('my_train_da')
+```
+You can pull a {class}`~docarray.document.DocumentArray` that has been pushed by another user if they pushed
+their {class}`~docarray.document.DocumentArray` with `public` set to `True`. To specify that you are pulling
+data pushed by another user, you need to prepend their user id, followed by a `/` character, to the name of the
+{class}`~docarray.document.DocumentArray`. For example, the code block below shows how you can pull the training data for the [Totally Looks Like Dataset](https://sites.google.com/view/totally-looks-like-dataset):
+```python
+from finetuner import DocumentArray
+
+my_data = DocumentArray.pull('finetuner/tll-train-da')
+```

--- a/docs/walkthrough/index.md
+++ b/docs/walkthrough/index.md
@@ -19,7 +19,7 @@ to address this by providing a simple interface, which can be as easy as:
 
 ```python
 import finetuner
-from docarray import DocumentArray
+from finetuner import DocumentArray
 
 # Login to Jina AI Cloud
 finetuner.login()

--- a/docs/walkthrough/inference.md
+++ b/docs/walkthrough/inference.md
@@ -106,7 +106,7 @@ To embed a [DocumentArray](https://docarray.jina.ai/) with a fine-tuned model, y
 
 ````{tab} Artifact id and token
 ```python
-from docarray import DocumentArray, Document
+from finetunerr import DocumentArray, Document
 import finetuner
 
 finetuner.login()
@@ -132,7 +132,7 @@ for doc in da:
 ````
 ````{tab} Locally saved artifact
 ```python
-from docarray import DocumentArray, Document
+from finetuner import DocumentArray, Document
 import finetuner
 
 model = finetuner.get_model('/path/to/YOUR-MODEL.zip')
@@ -147,7 +147,7 @@ for doc in da:
 ````
 ````{tab} (Special case) CLIP inference
 ```python
-from docarray import DocumentArray, Document
+from finetuner import DocumentArray, Document
 import finetuner
 
 finetuner.login()

--- a/docs/walkthrough/run-job.md
+++ b/docs/walkthrough/run-job.md
@@ -12,7 +12,7 @@ To start fine-tuning, you can call:
 
 ```python
 import finetuner
-from docarray import DocumentArray
+from finetunerr import DocumentArray
 
 train_data = 'path/to/some/data.csv'
 
@@ -67,7 +67,7 @@ Finetuner gives you the flexibility to set hyper-parameters explicitly:
 
 ```python
 import finetuner
-from docarray import DocumentArray
+from finetuner import DocumentArray
 from finetuner.data import CSVOptions
 
 train_data = 'path/to/some/train_data.csv'

--- a/finetuner/__init__.py
+++ b/finetuner/__init__.py
@@ -4,7 +4,7 @@ import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, TextIO, Union
 
 from _finetuner.runner.stubs import model as model_stub
-from docarray import DocumentArray
+from docarray import Document, DocumentArray  # noqa F401
 
 from finetuner.constants import (
     DEFAULT_FINETUNER_HOST,

--- a/finetuner/data.py
+++ b/finetuner/data.py
@@ -8,12 +8,12 @@ from io import StringIO
 from typing import TYPE_CHECKING, List, Optional, TextIO, Tuple, Union
 
 from _finetuner.runner.stubs.model import get_stub
-from docarray import Document, DocumentArray
-from docarray.document.generators import _subsample
-from docarray.document.mixins.helper import _is_uri
 from genericpath import isfile
 
+from finetuner import Document, DocumentArray
 from finetuner.constants import DEFAULT_TAG_KEY, DEFAULT_TAG_SCORE_KEY
+from finetuner.document.generators import _subsample
+from finetuner.document.mixins.helper import _is_uri
 
 if TYPE_CHECKING:
     from _finetuner.models.inference import InferenceEngine

--- a/finetuner/experiment.py
+++ b/finetuner/experiment.py
@@ -2,8 +2,8 @@ from dataclasses import fields
 from typing import Any, Dict, List, Optional, TextIO, Union
 
 from _finetuner.runner.stubs import config
-from docarray import DocumentArray
 
+from finetuner import DocumentArray
 from finetuner.callback import EvaluationCallback
 from finetuner.client import FinetunerV1Client
 from finetuner.constants import (

--- a/finetuner/finetuner.py
+++ b/finetuner/finetuner.py
@@ -1,8 +1,7 @@
 from typing import Any, Dict, List, Optional, Union
 
-from docarray import DocumentArray
-
 import hubble
+from finetuner import DocumentArray
 from finetuner.client import FinetunerV1Client
 from finetuner.constants import CREATED_AT, DESCRIPTION, NAME, STATUS
 from finetuner.data import CSVOptions

--- a/finetuner/hubble.py
+++ b/finetuner/hubble.py
@@ -1,8 +1,7 @@
 import os
 from typing import Dict, Optional, Tuple, Union
 
-from docarray import DocumentArray
-
+from finetuner import DocumentArray
 from finetuner.constants import ARTIFACTS_DIR, DA_PREFIX
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -2,11 +2,11 @@ import os
 
 import numpy as np
 import pytest
-from docarray import Document, DocumentArray
 from tests.constants import FINETUNER_LABEL
 
 import finetuner
 import hubble
+from finetuner import Document, DocumentArray
 
 
 @pytest.fixture()

--- a/tests/unit/test___init__.py
+++ b/tests/unit/test___init__.py
@@ -2,9 +2,9 @@ import numpy as np
 import pytest
 from _finetuner.excepts import SelectModelRequired
 from _finetuner.models.inference import ONNXRuntimeInferenceEngine, TorchInferenceEngine
-from docarray import Document, DocumentArray
 
 import finetuner
+from finetuner import Document, DocumentArray
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -3,8 +3,8 @@ import os
 from io import StringIO
 
 import pytest
-from docarray import Document, DocumentArray
 
+from finetuner import Document, DocumentArray
 from finetuner.constants import DEFAULT_TAG_KEY, DEFAULT_TAG_SCORE_KEY
 from finetuner.data import CSVContext, CSVOptions, check_columns, create_document
 


### PR DESCRIPTION
To avoid users relying on legacy documentation, this pr provides additional documentation on how to use DocumentArray for finetuner.

---

- [ ] This PR references an open issue
- [ ] I have added a line about this change to CHANGELOG