### PR TITLE
chore: bump black, flake8, isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,14 @@
 repos:
   - repo: https://github.com/ambv/black
-    rev: "22.3.0"
+    rev: "23.3.0"
     hooks:
       - id: black
         types: [python]
   - repo: https://github.com/pycqa/flake8
-    rev: "5.0.4"
+    rev: "6.0.0"
     hooks:
       - id: flake8
   - repo: https://github.com/pycqa/isort
-    rev: "5.10.1"
+    rev: "5.12.0"
     hooks:
       - id: isort

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Bump black, flake8 and isort ([#747](https://github.com/jina-ai/finetuner/pull/747))
+
 ### Fixed
 
 ### Docs

--- a/finetuner/data.py
+++ b/finetuner/data.py
@@ -89,7 +89,6 @@ class LabeledCSVParser(_CSVParser):
 
     def parse(self):
         with self._file_ctx as fp:
-
             lines = csv.reader(fp, dialect=self._options.dialect)
 
             for columns in _subsample(
@@ -125,7 +124,6 @@ class QueryDocumentRelationsParser(_CSVParser):
 
     def parse(self):
         with self._file_ctx as fp:
-
             queries = {}
             artificial_label = 0
             modality_col1, modality_col2 = None, None
@@ -197,7 +195,6 @@ class PairwiseScoreParser(_CSVParser):
 
     def parse(self):
         with self._file_ctx as fp:
-
             lines = csv.reader(fp, dialect=self._options.dialect)
 
             for columns in _subsample(

--- a/setup.py
+++ b/setup.py
@@ -37,9 +37,9 @@ if __name__ == '__main__':
                 'finetuner-commons==0.13.6',
             ],
             'test': [
-                'black==22.3.0',
-                'flake8==5.0.4',
-                'isort==5.10.1',
+                'black==23.3.0',
+                'flake8==6.0.0',
+                'isort==5.12.0',
                 'pytest==7.0.0',
                 'pytest-cov==3.0.0',
                 'pytest-mock==3.7.0',

--- a/tests/integration/test_data.py
+++ b/tests/integration/test_data.py
@@ -14,7 +14,6 @@ from finetuner.data import build_encoding_dataset
     ],
 )
 def test_build_encoding_dataset_str(data, model_name, modality):
-
     model = build_model(name=model_name, select_model='clip-' + modality)
     da = build_encoding_dataset(model=model, data=data)
     for doc, expected in zip(da, data):

--- a/tests/integration/test_experiments.py
+++ b/tests/integration/test_experiments.py
@@ -2,7 +2,6 @@ from tests.helper import create_random_name
 
 
 def test_experiments(finetuner_mocker):
-
     first_exp_name, second_exp_name = [create_random_name() for _ in range(2)]
 
     # create an experiment and retrieve it

--- a/tests/integration/test_runs.py
+++ b/tests/integration/test_runs.py
@@ -11,7 +11,6 @@ from finetuner.model import synthesis_model_en
 
 
 def test_runs(finetuner_mocker, get_feature_data):
-
     experiment_name = create_random_name()
 
     # get preprocessed data

--- a/tests/unit/test___init__.py
+++ b/tests/unit/test___init__.py
@@ -19,7 +19,6 @@ from finetuner import Document, DocumentArray
     ],
 )
 def test_build_model(descriptor, select_model, is_onnx, expect_error):
-
     if expect_error:
         with pytest.raises(expect_error):
             model = finetuner.build_model(
@@ -40,7 +39,6 @@ def test_build_model(descriptor, select_model, is_onnx, expect_error):
 
 @pytest.mark.parametrize('is_onnx', [True, False])
 def test_build_model_embedding(is_onnx):
-
     model = finetuner.build_model(name='bert-base-cased', is_onnx=is_onnx)
 
     da = DocumentArray(Document(text='TEST TEXT'))

--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -25,7 +25,6 @@ def dummy_csv_file():
 
 @pytest.mark.parametrize('data, is_file', [(dummy_csv_file(), True)])
 def test_build_dataset_str(data, is_file):
-
     options = CSVOptions(dialect='excel')
     csv_context = CSVContext(model='bert-base-cased', options=options)
 


### PR DESCRIPTION
<!--- PR Description here --->


---
Bump black to version 23.3.0, flake8 to 6.0.0 and isort to 5.12.0.
- [ ] This PR references an open issue
- [x] I have added a line about this change to CHANGELOG