### PR TITLE
fix: create synthesis run should accept da as input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix create synthesis run not accepting `DocumentArray` as input type. ([#748](https://github.com/jina-ai/finetuner/pull/748))
+
 ### Docs
 
 

--- a/finetuner/experiment.py
+++ b/finetuner/experiment.py
@@ -241,16 +241,16 @@ class Experiment:
             run_name = get_random_name()
 
         csv_context = CSVContext(None, options=csv_options)
-        query_data = (
-            csv_context.build_dataset(data=query_data)
-            if isinstance(query_data, str)
-            else DocumentArray([Document(text=data) for data in query_data])
-        )
-        corpus_data = (
-            csv_context.build_dataset(data=corpus_data)
-            if isinstance(query_data, str)
-            else DocumentArray([Document(text=data) for data in corpus_data])
-        )
+        if isinstance(query_data, str):
+            query_data = csv_context.build_dataset(data=query_data)
+        elif isinstance(query_data, list):
+            query_data = DocumentArray([Document(text=data) for data in query_data])
+
+        if isinstance(corpus_data, str):
+            corpus_data = csv_context.build_dataset(data=corpus_data)
+        elif isinstance(corpus_data, list):
+            corpus_data = DocumentArray([Document(text=data) for data in corpus_data])
+
         query_data, corpus_data = push_synthesis_data(
             experiment_name=self._name,
             run_name=run_name,


### PR DESCRIPTION
<!--- PR Description here --->

Create synthesis run currently only accepts a `str` is the name of the `DoccumentArray`, or a list of `str` which is to used to construct a `DocumentArray`, but if user give a DA, it is not accepted.

---

- [ ] This PR references an open issue
- [x] I have added a line about this change to CHANGELOG