### PR TITLE
chore: release 081

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Docs
 
+
+## [0.8.1] - 2023-07-26
+
+### Added
+
+### Removed
+
+### Changed
+
+### Fixed
+
+### Docs
+
 - Add tiny model and citation to Readme and docs. ([#763](https://github.com/jina-ai/finetuner/pull/763))
 
 - Fix huggingface link of jina embeddings. ([#761](https://github.com/jina-ai/finetuner/pull/761))

--- a/docs/walkthrough/choose-backbone.md
+++ b/docs/walkthrough/choose-backbone.md
@@ -49,6 +49,7 @@ to get a list of supported models:
 ┏━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 ┃                   name ┃         task ┃ output_dim ┃ architecture ┃                                                             description ┃
 ┡━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ jina-embedding-t-en-v1 │ text-to-text │        312 │  transformer │    Text embedding model trained using Linnaeus-Clean dataset by Jina AI │
 │ jina-embedding-s-en-v1 │ text-to-text │        512 │  transformer │    Text embedding model trained using Linnaeus-Clean dataset by Jina AI │
 │ jina-embedding-b-en-v1 │ text-to-text │        768 │  transformer │    Text embedding model trained using Linnaeus-Clean dataset by Jina AI │
 │ jina-embedding-l-en-v1 │ text-to-text │       1024 │  transformer │    Text embedding model trained using Linnaeus-Clean dataset by Jina AI │

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version = 0.8.0
+version = 0.8.1
 
 [flake8]
 # E501 is too long lines - ignore as black takes care of that

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,8 @@ if __name__ == '__main__':
         setup_requires=['setuptools>=18.0', 'wheel'],
         install_requires=[
             'docarray[common]<0.30.0',
-            'finetuner-stubs==0.13.9',
-            'finetuner-commons==0.13.9',
+            'finetuner-stubs==0.13.10',
+            'finetuner-commons==0.13.10',
         ],
         extras_require={
             'full': [


### PR DESCRIPTION
<!--- PR Description here --->

# Release Note Finetuner 0.8.1

This release covers Finetuner version 0.8.1, including dependency finetuner-core 0.13.10.

This release contains 1 new feature, 1 refactoring and 1 documentation improvement.

## 🆕 Features

### Add Jina Tiny Embedding model

We have included `jina-embedding-t-en-v1` in our list of supported models. This very small embedding model, comprising 14 million parameters, offers lightning-fast inference on CPUs.

In our experiments, it was able to encode 1730 sentences per second on a Macbook Pro Core-i5, making it perfectly suitable for edge devices. To utilize the Tiny model, follow these steps:


```python
!pip install finetuner
import finetuner

model = finetuner.build_model('jinaai/jina-embedding-t-en-v1')
embeddings = finetuner.encode(
    model=model,
    data=['how is the weather today', 'What is the current weather like today?']
)
print(finetuner.cos_sim(embeddings[0], embeddings[1]))
```

## ⚙ Refactoring

### Remove `typing-extensions` from Finetuner dependencies

We have eliminated the dependency on `typing-extensions` due to compatibility issues when using the Finetuner on Google Colab.

## 📗 Documentation Improvements

### Add Tiny model and technical report to Finetuner Readme and Docs. (https://github.com/jina-ai/finetuner/pull/763)

We have updated the documentation page to include information about `jina-embedding-t-en-v1`. We have also added technical reports and citation details to the README and documentation page.


## 🤟 Contributors

We would like to thank all contributors to this release:
- Wang Bo (@bwanglzu)
- Louis Milliken (@LMMilliken)
- Michael Günther (@guenthermi)
- George Mastrapas (@gmastrapas)
- Scott Martens (@scott-martens)


---

- [ ] This PR references an open issue
- [ ] I have added a line about this change to CHANGELOG